### PR TITLE
fix(client): stream parallel-upload slices instead of buffering in memory

### DIFF
--- a/resumable_upload/client/_fileslice.py
+++ b/resumable_upload/client/_fileslice.py
@@ -1,0 +1,66 @@
+# resumable_upload/client/_fileslice.py
+"""Read-on-demand view over a byte range of a file, shared by sync + async
+parallel uploads so a slice is never loaded into memory all at once."""
+
+from __future__ import annotations
+
+import io
+
+
+class FileSlice(io.RawIOBase):
+    """A read-only, seekable file-like view over ``[lo, lo + length)`` of *path*.
+
+    Positions are slice-relative (``0 .. length``). The uploader reads one
+    ``chunk_size`` block at a time, so memory use stays at one chunk instead of
+    the whole slice — the point of using this over ``io.BytesIO(f.read(length))``.
+
+    Owns its own file descriptor; the caller must :meth:`close` it (the uploader
+    treats an injected stream as not-owned and will not close it).
+    """
+
+    def __init__(self, path: str, lo: int, length: int) -> None:
+        super().__init__()
+        self._f = open(path, "rb")  # noqa: SIM115 — closed in close()
+        self._lo = lo
+        self._length = length
+        self._pos = 0
+        self._f.seek(lo)
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def seek(self, pos: int, whence: int = io.SEEK_SET) -> int:
+        if whence == io.SEEK_SET:
+            new = pos
+        elif whence == io.SEEK_CUR:
+            new = self._pos + pos
+        elif whence == io.SEEK_END:
+            new = self._length + pos
+        else:
+            raise ValueError(f"invalid whence: {whence}")
+        self._pos = max(0, min(new, self._length))
+        self._f.seek(self._lo + self._pos)
+        return self._pos
+
+    def tell(self) -> int:
+        return self._pos
+
+    def readinto(self, b) -> int:
+        remaining = self._length - self._pos
+        if remaining <= 0:
+            return 0
+        n = min(len(b), remaining)
+        data = self._f.read(n)
+        b[: len(data)] = data
+        self._pos += len(data)
+        return len(data)
+
+    def close(self) -> None:
+        try:
+            if not self._f.closed:
+                self._f.close()
+        finally:
+            super().close()

--- a/resumable_upload/client/aio/client.py
+++ b/resumable_upload/client/aio/client.py
@@ -3,30 +3,19 @@
 from __future__ import annotations
 
 import asyncio
-import io
 import os
 from collections.abc import Callable
 from typing import IO, Any
 from urllib.parse import urljoin
 
 from resumable_upload.client import _protocol
+from resumable_upload.client._fileslice import FileSlice
 from resumable_upload.client.aio import _http
 from resumable_upload.client.aio.uploader import AsyncUploader
 from resumable_upload.client.stats import UploadStats
 from resumable_upload.exceptions import TusCommunicationError
 from resumable_upload.fingerprint import Fingerprint
 from resumable_upload.url_storage import FileURLStorage, URLStorage
-
-
-def _read_slice(path: str, lo: int, length: int) -> bytes:
-    """Read ``length`` bytes from ``path`` starting at byte ``lo``.
-
-    Designed to be called via ``asyncio.to_thread`` so the blocking
-    file I/O is offloaded from the event loop.
-    """
-    with open(path, "rb") as f:
-        f.seek(lo)
-        return f.read(length)
 
 
 class AsyncTusClient:
@@ -356,12 +345,14 @@ class AsyncTusClient:
                 url = await self._create_upload(
                     length, {}, extra_headers={"Upload-Concat": "partial"}
                 )
-                buf = await asyncio.to_thread(_read_slice, file_path, lo, length)
+                # Stream the slice from disk on demand instead of reading it all
+                # into memory; opening the fd is blocking, so do it off-loop.
+                file_slice = await asyncio.to_thread(FileSlice, file_path, lo, length)
                 client = await self._ensure_client()
                 up = await AsyncUploader.open(
                     client,
                     url,
-                    file_stream=io.BytesIO(buf),
+                    file_stream=file_slice,
                     chunk_size=self.chunk_size,
                     checksum=self.checksum,
                     metadata_encoding=self.metadata_encoding,
@@ -378,6 +369,8 @@ class AsyncTusClient:
                     return url
                 finally:
                     await up.aclose()
+                    # Uploader does not own the injected stream — close it here.
+                    await asyncio.to_thread(file_slice.close)
 
         partial_urls = await asyncio.gather(*(upload_slice(lo, hi) for lo, hi in boundaries))
 

--- a/resumable_upload/client/parallel.py
+++ b/resumable_upload/client/parallel.py
@@ -25,8 +25,9 @@ class ParallelUploadMixin(_ClientAttrs):
         progress_callback: Optional[Callable[[UploadStats], None]],
     ) -> str:
         """Split a file into N ranges, upload concurrently, and merge server-side."""
-        import io
         from concurrent.futures import ThreadPoolExecutor
+
+        from resumable_upload.client._fileslice import FileSlice
 
         file_size = os.path.getsize(file_path)
         if file_size == 0:
@@ -51,12 +52,12 @@ class ParallelUploadMixin(_ClientAttrs):
             upload_url = self._create_upload(
                 length, metadata={}, extra_headers={"Upload-Concat": "partial"}
             )
-            with open(file_path, "rb") as f:
-                f.seek(lo)
-                buf = io.BytesIO(f.read(length))
+            # Stream the slice from disk on demand instead of reading it all
+            # into memory; the uploader does not own the stream, so close it here.
+            file_slice = FileSlice(file_path, lo, length)
             uploader = Uploader(
                 url=upload_url,
-                file_stream=buf,
+                file_stream=file_slice,  # ty: ignore[invalid-argument-type]
                 chunk_size=self.chunk_size,
                 checksum=self.checksum,
                 metadata_encoding=self.metadata_encoding,
@@ -74,6 +75,7 @@ class ParallelUploadMixin(_ClientAttrs):
                 return upload_url
             finally:
                 uploader.close()
+                file_slice.close()
 
         with ThreadPoolExecutor(max_workers=parallel_uploads) as pool:
             futures = [pool.submit(upload_slice, lo, hi) for lo, hi in boundaries]

--- a/tests/test_fileslice.py
+++ b/tests/test_fileslice.py
@@ -1,0 +1,71 @@
+"""Unit tests for the read-on-demand FileSlice used by parallel uploads."""
+
+import io
+
+from resumable_upload.client._fileslice import FileSlice
+
+
+def _write(tmp_path, data: bytes):
+    p = tmp_path / "data.bin"
+    p.write_bytes(data)
+    return str(p)
+
+
+def test_reads_only_its_range(tmp_path):
+    path = _write(tmp_path, b"0123456789")
+    fs = FileSlice(path, lo=3, length=4)  # bytes "3456"
+    try:
+        assert fs.read() == b"3456"
+        assert fs.read() == b""  # past end of slice, not into neighbor bytes
+    finally:
+        fs.close()
+
+
+def test_chunked_read_and_tell(tmp_path):
+    path = _write(tmp_path, b"abcdefghij")
+    fs = FileSlice(path, lo=2, length=6)  # "cdefgh"
+    try:
+        assert fs.read(2) == b"cd"
+        assert fs.tell() == 2
+        assert fs.read(2) == b"ef"
+        assert fs.read(99) == b"gh"  # clamped to slice end
+        assert fs.tell() == 6
+    finally:
+        fs.close()
+
+
+def test_seek_modes_and_clamping(tmp_path):
+    path = _write(tmp_path, b"0123456789")
+    fs = FileSlice(path, lo=1, length=5)  # "12345"
+    try:
+        assert fs.seek(0, io.SEEK_END) == 5
+        assert fs.read() == b""
+        assert fs.seek(2) == 2 and fs.read() == b"345"
+        fs.seek(1)
+        assert fs.seek(2, io.SEEK_CUR) == 3 and fs.read() == b"45"
+        assert fs.seek(-100) == 0  # clamped to start
+        assert fs.seek(100) == 5  # clamped to end
+    finally:
+        fs.close()
+
+
+def test_readinto(tmp_path):
+    path = _write(tmp_path, b"helloworld")
+    fs = FileSlice(path, lo=5, length=5)  # "world"
+    try:
+        buf = bytearray(3)
+        assert fs.readinto(buf) == 3
+        assert bytes(buf) == b"wor"
+        assert fs.readinto(buf) == 2  # only "ld" left
+        assert bytes(buf[:2]) == b"ld"
+        assert fs.readinto(buf) == 0  # exhausted
+    finally:
+        fs.close()
+
+
+def test_close_releases_descriptor(tmp_path):
+    path = _write(tmp_path, b"abc")
+    fs = FileSlice(path, lo=0, length=3)
+    fs.close()
+    assert fs._f.closed
+    fs.close()  # idempotent


### PR DESCRIPTION
## Purpose
Closes #3. Parallel uploads read each byte-range slice fully into memory (`io.BytesIO(f.read(length))`), so with `parallel_uploads=N` the in-flight slices summed to the whole file — an OOM risk for large files. Raised by gemini-code-assist on #1, deferred from #2.

## Changes
- Add `resumable_upload/client/_fileslice.py` — `FileSlice`, a read-only, seekable, range-bounded (`io.RawIOBase`) view that reads on demand. The uploader pulls one `chunk_size` block at a time, so memory use is **one chunk per active slice** instead of the whole slice.
- Wire it into both clients for parity: sync `client/parallel.py` and async `client/aio/client.py` (replacing the old `_read_slice` + `BytesIO`).
- Each path closes its `FileSlice` explicitly — the uploader treats an injected stream as not-owned and will not close it.

## TUS compliance
Client-side only. No change to wire bytes, headers, status codes, or offset semantics — same bytes are sent, just read incrementally from disk.

## Test Plan
```bash
pytest -q
ruff check resumable_upload tests && ruff format --check resumable_upload tests
ty check resumable_upload
```

## Test Result
- `pytest` — **503 passed, 4 skipped** (+5 new `FileSlice` unit tests; existing sync+async parallel/concat suites now exercise `FileSlice` end-to-end)
- `ruff check` / `ruff format --check` / `ty check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)