### PR TITLE
feat(cli): add upload, download, and info client commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,19 +171,21 @@ app.mount("/files", TusASGIApp(tus))
 
 The adapter awaits `TusServer.handle_request_async` directly. Storage backends that keep the default `*_async` implementations inherit `asyncio.to_thread`-based wrappers, so the event loop stays free with no rewrite required. Storage backends that override `*_async` with native async I/O run non-blocking end-to-end.
 
-### Command-line Server
+### Command-line Server & Client
 
-Run a TUS server from the shell without writing any Python:
+Run a TUS server, or upload/download/inspect against one, from the shell — no Python needed:
 
 ```bash
-# Console script (installed via pip/uv)
+# Server
 resumable-upload serve --host 0.0.0.0 --port 8080 --upload-dir ./uploads
 
-# Or via module invocation
-python -m resumable_upload serve --port 8080
+# Client: upload (resumable, progress line), inspect, download
+resumable-upload upload big.bin --url http://host/files --parallel 4
+resumable-upload info http://host/files/<id>
+resumable-upload download http://host/files/<id> -o out.bin
 ```
 
-Flags: `--host`, `--port`, `--base-path`, `--upload-dir`, `--db-path`, `--max-size`, `--max-chunk-size`, `--upload-expiry`, `--cors-origin`, `--cors-credentials`, `--cors-max-age`, `--checksum-algorithms`, `--enable-downloads`, `--behind-proxy`, `--location-base-url`, `--disable-termination`, `--disable-concatenation`, `--metrics-path`, `--lock-backend`, `--redis-url`, `--log-level`. Run `resumable-upload serve --help` for details.
+Server flags: `--host`, `--port`, `--base-path`, `--upload-dir`, `--db-path`, `--max-size`, `--max-chunk-size`, `--upload-expiry`, `--cors-origin`, `--cors-credentials`, `--cors-max-age`, `--checksum-algorithms`, `--enable-downloads`, `--behind-proxy`, `--location-base-url`, `--disable-termination`, `--disable-concatenation`, `--metrics-path`, `--lock-backend`, `--redis-url`, `--log-level`. Run `resumable-upload serve --help` for details.
 
 ### Parallel chunk uploads
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -55,4 +55,37 @@ resumable-upload serve \
 resumable-upload serve --max-chunk-size $((50 * 1024 * 1024))
 ```
 
+## Client commands
+
+The same console script also uploads, downloads, and inspects uploads against
+any TUS server — no Python needed.
+
+```bash
+# Upload (resumable, with a progress line); prints the upload URL
+resumable-upload upload big.bin --url http://host/files
+
+# Split into concurrent partials and merge server-side (concatenation)
+resumable-upload upload big.bin --url http://host/files --parallel 4
+
+# Attach metadata (repeatable); filename is added automatically
+resumable-upload upload report.pdf --url http://host/files --metadata title="Q3"
+
+# Inspect an upload (HEAD): offset, length, complete, metadata
+resumable-upload info http://host/files/<id>
+
+# Download a completed upload (needs the server's GET endpoint)
+resumable-upload download http://host/files/<id> -o out.bin
+```
+
+### `upload` flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--url` | required | TUS creation endpoint |
+| `--chunk-size` | `4194304` | Chunk size in bytes (4 MB) |
+| `--parallel` | `1` | Concurrent partial uploads (concatenation) |
+| `--metadata KEY=VALUE` | — | Upload metadata, repeatable |
+| `--checksum` | `sha1` | Checksum algorithm, or `none` to disable |
+| `--no-progress` | off | Suppress the progress line |
+
 The CLI handles `SIGINT` / `SIGTERM` cleanly and shuts the HTTP server down before exiting.

--- a/resumable_upload/cli.py
+++ b/resumable_upload/cli.py
@@ -127,6 +127,40 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Redis URL (e.g., redis://localhost:6379/0), required when --lock-backend=redis",
     )
+
+    # -- client subcommands ------------------------------------------------
+    upload = sub.add_parser("upload", help="Upload a file to a TUS server.")
+    upload.add_argument("file", help="Path to the file to upload")
+    upload.add_argument(
+        "--url", required=True, help="TUS creation endpoint, e.g. http://host/files"
+    )
+    upload.add_argument(
+        "--chunk-size", type=int, default=4 * 1024 * 1024, help="Chunk size in bytes (default: 4MB)"
+    )
+    upload.add_argument(
+        "--parallel", type=int, default=1, help="Concurrent partial uploads (default: 1)"
+    )
+    upload.add_argument(
+        "--metadata",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Upload metadata (repeatable); filename is added automatically",
+    )
+    upload.add_argument(
+        "--checksum",
+        default="sha1",
+        help="Checksum algorithm, or 'none' to disable (default: sha1)",
+    )
+    upload.add_argument("--no-progress", action="store_true", help="Suppress the progress line")
+
+    download = sub.add_parser("download", help="Download a completed upload (server GET endpoint).")
+    download.add_argument("url", help="Upload URL to download")
+    download.add_argument("-o", "--output", required=True, help="Output file path")
+
+    info = sub.add_parser("info", help="Print offset/length/metadata for an upload (HEAD).")
+    info.add_argument("url", help="Upload URL to inspect")
+
     return parser
 
 
@@ -211,11 +245,79 @@ def _serve(args: argparse.Namespace) -> int:
     return 0
 
 
+def _parse_metadata(pairs: list[str]) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for item in pairs:
+        if "=" not in item:
+            raise SystemExit(f"--metadata must be KEY=VALUE, got: {item}")
+        key, value = item.split("=", 1)
+        metadata[key] = value
+    return metadata
+
+
+def _upload(args: argparse.Namespace) -> int:
+    import os
+
+    from resumable_upload.client import TusClient
+    from resumable_upload.client.stats import UploadStats
+
+    checksum: bool | str = False if args.checksum.lower() == "none" else args.checksum
+    metadata = _parse_metadata(args.metadata)
+    metadata.setdefault("filename", os.path.basename(args.file))
+
+    def _progress(stats: UploadStats) -> None:
+        pct = (stats.uploaded_bytes / stats.total_bytes * 100) if stats.total_bytes else 100.0
+        print(
+            f"\r  {pct:5.1f}%  {stats.uploaded_bytes}/{stats.total_bytes} bytes",
+            end="",
+            flush=True,
+        )
+
+    client = TusClient(args.url, chunk_size=args.chunk_size, checksum=checksum)
+    url = client.upload_file(
+        args.file,
+        metadata=metadata,
+        parallel_uploads=args.parallel,
+        progress_callback=None if args.no_progress else _progress,
+    )
+    if not args.no_progress:
+        print()  # end the progress line
+    print(url)
+    return 0
+
+
+def _download(args: argparse.Namespace) -> int:
+    import shutil
+    import urllib.request
+
+    with urllib.request.urlopen(args.url) as resp, open(args.output, "wb") as out:
+        shutil.copyfileobj(resp, out)
+    print(f"Saved {args.output}")
+    return 0
+
+
+def _info(args: argparse.Namespace) -> int:
+    from resumable_upload.client import TusClient
+
+    client = TusClient(args.url)
+    inf = client.get_upload_info(args.url)
+    print(f"offset:   {inf['offset']}")
+    print(f"length:   {inf['length']}")
+    print(f"complete: {inf['complete']}")
+    if inf.get("metadata"):
+        print("metadata:")
+        for k, v in inf["metadata"].items():
+            print(f"  {k}: {v}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
-    if args.command == "serve":
-        return _serve(args)
+    handlers = {"serve": _serve, "upload": _upload, "download": _download, "info": _info}
+    handler = handlers.get(args.command)
+    if handler is not None:
+        return handler(args)
     parser.print_help()
     return 1
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,7 +144,7 @@ class TestCLI:
             except subprocess.TimeoutExpired:
                 proc.kill()
 
-    def test_cli_serve_cors_credentials_max_age_and_checksums(self, tmp_path):
+    def test_cli_serve_cors_credentials_max_age_and_checksums(self, tmp_path):  # noqa: PLR0915
         port = _find_free_port()
         proc = subprocess.Popen(
             [
@@ -198,3 +198,90 @@ class TestCLI:
                 proc.wait(timeout=2)
             except subprocess.TimeoutExpired:
                 proc.kill()
+
+
+@pytest.fixture
+def cli_server(tmp_path):
+    """In-process TUS server (downloads on) for the client-side CLI tests."""
+    import threading
+    from http.server import HTTPServer
+
+    from resumable_upload.server import TusHTTPRequestHandler, TusServer
+    from resumable_upload.storage import SQLiteStorage
+
+    tus = TusServer(
+        storage=SQLiteStorage(db_path=str(tmp_path / "u.db"), upload_dir=str(tmp_path / "f")),
+        base_path="/files",
+        enable_downloads=True,
+    )
+
+    class Handler(TusHTTPRequestHandler):
+        pass
+
+    Handler.tus_server = tus
+    httpd = HTTPServer(("127.0.0.1", 0), Handler)
+    port = httpd.server_address[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    try:
+        yield f"http://127.0.0.1:{port}/files"
+    finally:
+        httpd.shutdown()
+        httpd.server_close()
+
+
+def _cli(*args: str):
+    return subprocess.run(
+        [sys.executable, "-m", "resumable_upload", *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+class TestCLIClient:
+    def test_upload_info_download_roundtrip(self, cli_server, tmp_path):
+        src = tmp_path / "src.bin"
+        src.write_bytes(b"Z" * 5000)
+
+        up = _cli(
+            "upload",
+            str(src),
+            "--url",
+            cli_server,
+            "--chunk-size",
+            "1024",
+            "--metadata",
+            "author=me",
+            "--no-progress",
+        )
+        assert up.returncode == 0, up.stderr
+        url = up.stdout.strip().splitlines()[-1]
+        assert url.startswith(cli_server + "/")
+
+        inf = _cli("info", url)
+        assert inf.returncode == 0, inf.stderr
+        assert "complete: True" in inf.stdout
+        assert "author: me" in inf.stdout
+        assert "filename: src.bin" in inf.stdout
+
+        out = tmp_path / "out.bin"
+        dl = _cli("download", url, "-o", str(out))
+        assert dl.returncode == 0, dl.stderr
+        assert out.read_bytes() == b"Z" * 5000
+
+    def test_upload_parallel(self, cli_server, tmp_path):
+        src = tmp_path / "big.bin"
+        src.write_bytes(b"Q" * 20000)
+        up = _cli("upload", str(src), "--url", cli_server, "--parallel", "3", "--no-progress")
+        assert up.returncode == 0, up.stderr
+        url = up.stdout.strip().splitlines()[-1]
+        out = tmp_path / "o.bin"
+        assert _cli("download", url, "-o", str(out)).returncode == 0
+        assert out.read_bytes() == b"Q" * 20000
+
+    def test_upload_bad_metadata(self, cli_server, tmp_path):
+        src = tmp_path / "s.bin"
+        src.write_bytes(b"x")
+        up = _cli("upload", str(src), "--url", cli_server, "--metadata", "novalue", "--no-progress")
+        assert up.returncode != 0
+        assert "KEY=VALUE" in up.stderr


### PR DESCRIPTION
## Purpose

Client-side CLI subcommands on the `resumable-upload` console script — no Python needed. Stacked on `feat/proxy-location`.

- `upload <file> --url` (resumable, progress, `--parallel`, `--metadata`, `--checksum`)
- `download <url> -o <out>` (server GET endpoint)
- `info <url>` (HEAD: offset / length / complete / metadata)

Docs: `docs/operations/cli.md` + README + README.ko + CHANGELOG.

## Test Plan

- `tests/test_cli.py::TestCLIClient` — roundtrip, parallel, bad-metadata against an in-process server
- `make ci`

## Test Result

- `pytest -v` green; `ruff` + `ty check` clean

---

<details>
<summary>Checklist</summary>

- [x] PR title follows Conventional Commits (`type(scope): ...`)
- [x] `pytest -v` passes locally
- [x] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [x] Tests added for new behavior or regression
- [x] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [x] Docs / examples updated if user-facing behavior changed

</details>
