### PR TITLE
test(interop): cross-implementation interop lanes vs tusd, tus-js, tus-py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,16 @@ test-all-versions:
 ci: lint format-check type-check test
 	@echo "✅ All CI checks passed!"
 
-# Four interop lanes: ours<->ours always; tusd<->our-client needs `tusd` on
-# PATH (or TUSD_BIN); our-server<->tus-js-client needs node; our-server<->
-# tus-py-client needs tuspy. Provisions the JS + Python reference clients;
-# missing tusd just skips lane 2.
+# Four interop pairings: ours<->ours always; our-client<->tusd, our-server<->
+# tus-js-client, our-server<->tus-py-client each need their reference impl.
+# Provisions all three reference clients (tusd for the host OS/arch is fetched
+# from GitHub releases); anything that fails to provision just skips.
 interop:
-	@command -v npm >/dev/null 2>&1 && (cd tests/interop && npm install --silent) || echo "npm not found — tus-js-client lane will skip"
-	@command -v uv >/dev/null 2>&1 && uv pip install --quiet tuspy || $(RUN) pip install --quiet tuspy || echo "tuspy install failed — tus-py-client lane will skip"
-	$(RUN) pytest tests/test_interop.py -v
+	@command -v npm >/dev/null 2>&1 && (cd tests/interop && npm install --silent) || echo "npm not found — tus-js-client pairing will skip"
+	@command -v uv >/dev/null 2>&1 && uv pip install --quiet tuspy || $(RUN) pip install --quiet tuspy || echo "tuspy install failed — tus-py-client pairing will skip"
+	@TUSD_BIN=$$(command -v tusd || sh tests/interop/fetch_tusd.sh 2>/dev/null || true); \
+	 [ -n "$$TUSD_BIN" ] && echo "using tusd: $$TUSD_BIN" || echo "tusd unavailable — tusd pairing will skip"; \
+	 TUSD_BIN=$$TUSD_BIN $(RUN) pytest tests/test_interop.py -v
 
 clean:
 	rm -rf build/ dist/ *.egg-info .coverage htmlcov/ .pytest_cache/ .ruff_cache/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-pip lint format format-check type-check test test-all test-all-versions ci clean
+.PHONY: help install install-pip lint format format-check type-check test test-all test-all-versions ci clean interop
 
 # Use Python from activated virtual environment if available, otherwise detect
 # Priority: .venv/bin/python > venv/bin/python > VIRTUAL_ENV/bin/python > python3 from PATH
@@ -19,6 +19,7 @@ help:
 	@echo "  make test             - Run all tests (including web frameworks)"
 	@echo "  make test-all-versions - Run tests on all Python versions (requires tox)"
 	@echo "  make ci               - Run full CI checks (lint, format-check, type-check, test)"
+	@echo "  make interop          - Cross-impl tests (tusd, tus-js-client, tus-py-client)"
 	@echo "  make clean            - Clean build artifacts"
 	@echo ""
 	@echo "Note: Make sure to activate your virtual environment first:"
@@ -58,6 +59,15 @@ test-all-versions:
 
 ci: lint format-check type-check test
 	@echo "✅ All CI checks passed!"
+
+# Four interop lanes: ours<->ours always; tusd<->our-client needs `tusd` on
+# PATH (or TUSD_BIN); our-server<->tus-js-client needs node; our-server<->
+# tus-py-client needs tuspy. Provisions the JS + Python reference clients;
+# missing tusd just skips lane 2.
+interop:
+	@command -v npm >/dev/null 2>&1 && (cd tests/interop && npm install --silent) || echo "npm not found — tus-js-client lane will skip"
+	@command -v uv >/dev/null 2>&1 && uv pip install --quiet tuspy || $(RUN) pip install --quiet tuspy || echo "tuspy install failed — tus-py-client lane will skip"
+	$(RUN) pytest tests/test_interop.py -v
 
 clean:
 	rm -rf build/ dist/ *.egg-info .coverage htmlcov/ .pytest_cache/ .ruff_cache/

--- a/README.ko.md
+++ b/README.ko.md
@@ -273,7 +273,26 @@ make lint              # 린팅
 make format            # 코드 포맷팅
 make test-all-versions # 모든 Python 버전 테스트 (3.9-3.14, tox 필요)
 make ci                # 전체 CI 검사 (린팅 + 포맷팅 + 테스트)
+make interop           # 구현체 간 호환성 테스트 (아래 참고)
 ```
+
+### 상호운용성 테스트 (로컬 전용, 선택)
+
+`make interop`은 실제 와이어 호환성을 TUS 생태계 대비 검증합니다
+(`tests/test_interop.py`). **로컬에서만** 실행되며 — `make ci`에 포함되지 않음 —
+전제 조건이 없는 조합은 자동으로 스킵됩니다:
+
+| 조합 | 커버 | 전제 조건 |
+|------|------|-----------|
+| 우리 서버 ↔ 우리 클라이언트 | 업로드, 재개, concatenation, 다운로드 | 없음 (항상 실행) |
+| 우리 클라이언트 ↔ **tusd** 서버 | 업로드, concatenation, termination | `tusd`가 `PATH`에 (또는 `TUSD_BIN=<경로>`) |
+| 우리 서버 ↔ **tus-js-client** (Node) | 업로드, HEAD, 다운로드, termination | `node` + `tests/interop/`에서 `npm install` |
+| 우리 서버 ↔ **tus-py-client** (`tuspy`) | 업로드, 재개, checksum | `uv pip install tuspy` |
+
+tusd는 클라이언트 바이너리를 제공하지 않으므로(서버 전용), 우리 서버를 때리는
+두 번째 레퍼런스 클라이언트는 tus 프로젝트의 공식 Python 클라이언트입니다. 각 조합은
+상대 구현이 지원하는 기능만 검증합니다 — 예를 들어 tusd는 checksum·expiration을
+광고하지 않고, tus-py-client는 termination 호출을 제공하지 않으므로 해당 조합은 의도적으로 스킵됩니다.
 
 ## 📖 문서
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,27 @@ make test-minimal      # Run minimal tests
 make test              # Run all tests
 make test-all-versions # Test on all Python versions (3.9-3.14) - requires tox
 make ci                # Run full CI checks (lint + format + test)
+make interop           # Cross-implementation interop tests (see below)
 ```
+
+### Interoperability tests (local, opt-in)
+
+`make interop` verifies real wire compatibility against the TUS ecosystem
+(in `tests/test_interop.py`). These run **locally only** — they are not part
+of `make ci`, and each pairing skips cleanly when its prerequisite is missing:
+
+| Pairing | Covers | Prerequisite |
+|---------|--------|--------------|
+| our server ↔ our client | upload, resume, concatenation, download | none (always runs) |
+| our client ↔ **tusd** server | upload, concatenation, termination | `tusd` on `PATH` (or `TUSD_BIN=<path>`) |
+| our server ↔ **tus-js-client** (Node) | upload, HEAD, download, termination | `node` + `npm install` in `tests/interop/` |
+| our server ↔ **tus-py-client** (`tuspy`) | upload, resume, checksum | `uv pip install tuspy` |
+
+`tusd` ships no client binary (server only), so the second reference client
+against our server is the tus project's Python client. Each pairing exercises
+only the features the counterpart implements — e.g. tusd advertises neither
+checksum nor expiration, and tus-py-client exposes no termination call, so
+those combinations are intentionally skipped.
 
 ## 📖 Documentation
 

--- a/tests/interop/.gitignore
+++ b/tests/interop/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/tests/interop/.gitignore
+++ b/tests/interop/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+tusd/

--- a/tests/interop/fetch_tusd.sh
+++ b/tests/interop/fetch_tusd.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+# Download the latest tusd release binary from GitHub into tests/interop/tusd/
+# (gitignored) and print its path. Skips the download if already present;
+# delete tests/interop/tusd/ to force a refresh to the newest release.
+set -e
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="$DIR/tusd/tusd"
+
+if [ -x "$BIN" ]; then
+    echo "$BIN"
+    exit 0
+fi
+
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64 | amd64) ARCH=amd64 ;;
+    aarch64 | arm64) ARCH=arm64 ;;
+    *)
+        echo "fetch_tusd: unsupported arch: $ARCH" >&2
+        exit 1
+        ;;
+esac
+case "$OS" in
+    linux | darwin) ;;
+    *)
+        echo "fetch_tusd: unsupported os: $OS" >&2
+        exit 1
+        ;;
+esac
+
+ASSET="tusd_${OS}_${ARCH}"
+URL="https://github.com/tus/tusd/releases/latest/download/${ASSET}.zip"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+echo "fetch_tusd: downloading latest tusd ($ASSET)..." >&2
+curl -fsSL "$URL" -o "$TMP/tusd.zip"
+unzip -q -o "$TMP/tusd.zip" -d "$TMP"
+mkdir -p "$DIR/tusd"
+cp "$TMP/$ASSET/tusd" "$BIN"
+chmod +x "$BIN"
+echo "$BIN"

--- a/tests/interop/package.json
+++ b/tests/interop/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "resumable-upload-interop",
+  "private": true,
+  "description": "JS-side dependencies for the cross-implementation interop tests",
+  "dependencies": {
+    "tus-js-client": "^4.3.1"
+  }
+}

--- a/tests/interop/tus_js_client.mjs
+++ b/tests/interop/tus_js_client.mjs
@@ -1,0 +1,45 @@
+// tus-js-client (Node) -> resumable-upload TusServer.
+// Usage: node tus_js_client.mjs <endpoint> <size-in-bytes> [mode]
+//   mode = "roundtrip" (default): upload, HEAD, download, SHA compare
+//          "terminate": upload, then abort(true) to DELETE, expect 404
+import crypto from "node:crypto";
+import * as tus from "tus-js-client";
+
+const [endpoint, sizeStr, mode = "roundtrip"] = process.argv.slice(2);
+const SIZE = Number(sizeStr);
+const data = crypto.randomBytes(SIZE);
+const sha = crypto.createHash("sha256").update(data).digest("hex");
+
+function doUpload() {
+  return new Promise((resolve, reject) => {
+    const upload = new tus.Upload(data, {
+      endpoint,
+      chunkSize: 256 * 1024,
+      retryDelays: [0, 100],
+      metadata: { filename: "interop.bin", filetype: "application/octet-stream" },
+      onError: reject,
+      onSuccess: () => resolve(upload),
+    });
+    upload.start();
+  });
+}
+
+const upload = await doUpload();
+const url = upload.url;
+
+if (mode === "terminate") {
+  // tus-js-client abort(true) issues the TUS termination DELETE.
+  await upload.abort(true);
+  const head = await fetch(url, { method: "HEAD", headers: { "Tus-Resumable": "1.0.0" } });
+  if (head.status !== 404) throw new Error(`expected 404 after terminate, got ${head.status}`);
+  console.log("OK terminated " + url);
+} else {
+  const head = await fetch(url, { method: "HEAD", headers: { "Tus-Resumable": "1.0.0" } });
+  if (head.headers.get("upload-offset") !== String(SIZE))
+    throw new Error(`bad offset: ${head.headers.get("upload-offset")}`);
+
+  const got = Buffer.from(await (await fetch(url)).arrayBuffer());
+  const gotSha = crypto.createHash("sha256").update(got).digest("hex");
+  if (gotSha !== sha) throw new Error("sha mismatch on download");
+  console.log("OK " + url);
+}

--- a/tests/interop/tus_js_client.mjs
+++ b/tests/interop/tus_js_client.mjs
@@ -1,22 +1,29 @@
 // tus-js-client (Node) -> resumable-upload TusServer.
 // Usage: node tus_js_client.mjs <endpoint> <size-in-bytes> [mode]
-//   mode = "roundtrip" (default): upload, HEAD, download, SHA compare
-//          "terminate": upload, then abort(true) to DELETE, expect 404
+//   roundtrip (default): upload, HEAD offset, download, SHA compare
+//   terminate: upload, then abort(true) to DELETE, expect 404
+//   empty:     upload a 0-byte file, expect offset 0 and empty download
+//   metadata:  upload with metadata, verify HEAD echoes Upload-Metadata
+//   smallchunk: upload with a tiny chunkSize (many PATCHes)
+//   resume:    upload one chunk, abort, resume via uploadUrl, verify bytes
 import crypto from "node:crypto";
 import * as tus from "tus-js-client";
 
 const [endpoint, sizeStr, mode = "roundtrip"] = process.argv.slice(2);
 const SIZE = Number(sizeStr);
-const data = crypto.randomBytes(SIZE);
+const data = mode === "empty" ? Buffer.alloc(0) : crypto.randomBytes(SIZE);
 const sha = crypto.createHash("sha256").update(data).digest("hex");
 
-function doUpload() {
+const HEAD_HEADERS = { "Tus-Resumable": "1.0.0" };
+
+function makeUpload(extra = {}) {
   return new Promise((resolve, reject) => {
     const upload = new tus.Upload(data, {
       endpoint,
-      chunkSize: 256 * 1024,
+      chunkSize: extra.chunkSize ?? 256 * 1024,
       retryDelays: [0, 100],
-      metadata: { filename: "interop.bin", filetype: "application/octet-stream" },
+      metadata:
+        extra.metadata ?? { filename: "interop.bin", filetype: "application/octet-stream" },
       onError: reject,
       onSuccess: () => resolve(upload),
     });
@@ -24,22 +31,69 @@ function doUpload() {
   });
 }
 
-const upload = await doUpload();
-const url = upload.url;
+async function downloadSha(url) {
+  const got = Buffer.from(await (await fetch(url)).arrayBuffer());
+  return crypto.createHash("sha256").update(got).digest("hex");
+}
 
 if (mode === "terminate") {
-  // tus-js-client abort(true) issues the TUS termination DELETE.
+  const upload = await makeUpload();
   await upload.abort(true);
-  const head = await fetch(url, { method: "HEAD", headers: { "Tus-Resumable": "1.0.0" } });
+  const head = await fetch(upload.url, { method: "HEAD", headers: HEAD_HEADERS });
   if (head.status !== 404) throw new Error(`expected 404 after terminate, got ${head.status}`);
-  console.log("OK terminated " + url);
+  console.log("OK terminated " + upload.url);
+} else if (mode === "empty") {
+  const upload = await makeUpload();
+  const head = await fetch(upload.url, { method: "HEAD", headers: HEAD_HEADERS });
+  if (head.headers.get("upload-offset") !== "0")
+    throw new Error(`empty offset: ${head.headers.get("upload-offset")}`);
+  const got = Buffer.from(await (await fetch(upload.url)).arrayBuffer());
+  if (got.length !== 0) throw new Error(`empty download not empty: ${got.length}`);
+  console.log("OK empty " + upload.url);
+} else if (mode === "metadata") {
+  const upload = await makeUpload({ metadata: { filename: "wîndé.bin", filetype: "image/png" } });
+  const head = await fetch(upload.url, { method: "HEAD", headers: HEAD_HEADERS });
+  const meta = head.headers.get("upload-metadata") || "";
+  const decoded = Object.fromEntries(
+    meta.split(",").map((kv) => {
+      const [k, v] = kv.trim().split(" ");
+      return [k, v ? Buffer.from(v, "base64").toString("utf-8") : ""];
+    }),
+  );
+  if (decoded.filename !== "wîndé.bin") throw new Error(`filename lost: ${decoded.filename}`);
+  if (decoded.filetype !== "image/png") throw new Error(`filetype lost: ${decoded.filetype}`);
+  console.log("OK metadata " + upload.url);
+} else if (mode === "smallchunk") {
+  const upload = await makeUpload({ chunkSize: 64 * 1024 });
+  if ((await downloadSha(upload.url)) !== sha) throw new Error("smallchunk sha mismatch");
+  console.log("OK smallchunk " + upload.url);
+} else if (mode === "resume") {
+  // Upload one chunk, abort, then resume against the same uploadUrl.
+  const url = await new Promise((resolve, reject) => {
+    const up = new tus.Upload(data, {
+      endpoint,
+      chunkSize: 256 * 1024,
+      onChunkComplete: () => up.abort().then(() => resolve(up.url)),
+      onError: reject,
+    });
+    up.start();
+  });
+  await new Promise((resolve, reject) => {
+    const up = new tus.Upload(data, {
+      uploadUrl: url,
+      chunkSize: 256 * 1024,
+      onSuccess: resolve,
+      onError: reject,
+    });
+    up.start();
+  });
+  if ((await downloadSha(url)) !== sha) throw new Error("resume sha mismatch");
+  console.log("OK resume " + url);
 } else {
-  const head = await fetch(url, { method: "HEAD", headers: { "Tus-Resumable": "1.0.0" } });
+  const upload = await makeUpload();
+  const head = await fetch(upload.url, { method: "HEAD", headers: HEAD_HEADERS });
   if (head.headers.get("upload-offset") !== String(SIZE))
     throw new Error(`bad offset: ${head.headers.get("upload-offset")}`);
-
-  const got = Buffer.from(await (await fetch(url)).arrayBuffer());
-  const gotSha = crypto.createHash("sha256").update(got).digest("hex");
-  if (gotSha !== sha) throw new Error("sha mismatch on download");
-  console.log("OK " + url);
+  if ((await downloadSha(upload.url)) !== sha) throw new Error("sha mismatch on download");
+  console.log("OK " + upload.url);
 }

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -1,0 +1,296 @@
+"""Cross-implementation interop tests.
+
+Each test class pairs one of our components with a real counterpart from the
+TUS ecosystem, exercising only the features the counterpart implements:
+
+- ``TestNativeRoundTrip``      — our server  <-> our client (always runs)
+- ``TestClientAgainstTusd``    — tusd server <-> our client (needs ``tusd``)
+- ``TestServerAgainstTusJs``   — our server  <-> tus-js-client (needs node)
+- ``TestServerAgainstTusPy``   — our server  <-> tus-py-client (needs ``tuspy``)
+
+Classes whose prerequisite is missing skip cleanly, so the default test run
+stays green everywhere; ``make interop`` provisions the reference clients and
+runs the lot. Override the tusd binary with ``TUSD_BIN``.
+"""
+
+import hashlib
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from http.server import HTTPServer
+
+import pytest
+
+from resumable_upload.client import TusClient
+from resumable_upload.server import TusHTTPRequestHandler, TusServer
+from resumable_upload.storage import SQLiteStorage
+
+INTEROP_DIR = os.path.join(os.path.dirname(__file__), "interop")
+TUSD_BIN = os.environ.get("TUSD_BIN") or shutil.which("tusd")
+NODE_BIN = shutil.which("node")
+HAS_TUS_JS = os.path.isdir(os.path.join(INTEROP_DIR, "node_modules", "tus-js-client"))
+
+try:
+    from tusclient import client as tuspy_client  # tus-py-client (PyPI: tuspy)
+
+    HAS_TUS_PY = True
+except ImportError:
+    HAS_TUS_PY = False
+
+PAYLOAD = os.urandom(2 * 1024 * 1024 + 77)  # > chunk size, odd length
+PAYLOAD_SHA = hashlib.sha256(PAYLOAD).hexdigest()
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_until_up(url: str, timeout: float = 10.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(url, method="OPTIONS")
+            with urllib.request.urlopen(req, timeout=1):
+                return
+        except Exception:
+            time.sleep(0.05)
+    raise RuntimeError(f"server at {url} never came up")
+
+
+def _download_sha(url: str) -> str:
+    with urllib.request.urlopen(url) as resp:
+        return hashlib.sha256(resp.read()).hexdigest()
+
+
+@pytest.fixture
+def ours_server():
+    """resumable-upload TusServer over real HTTP; yields (base_url, storage)."""
+    temp_dir = tempfile.mkdtemp()
+    storage = SQLiteStorage(
+        db_path=os.path.join(temp_dir, "u.db"),
+        upload_dir=os.path.join(temp_dir, "files"),
+    )
+    tus = TusServer(
+        storage=storage,
+        base_path="/files",
+        enable_downloads=True,
+        supports_checksum_trailer=True,
+        cors_allow_origins="*",
+    )
+
+    class Handler(TusHTTPRequestHandler):
+        pass
+
+    Handler.tus_server = tus
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{port}/files", storage
+    finally:
+        server.shutdown()
+        server.server_close()
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+@pytest.fixture
+def payload_file(tmp_path):
+    p = tmp_path / "payload.bin"
+    p.write_bytes(PAYLOAD)
+    return str(p)
+
+
+class TestNativeRoundTrip:
+    """our server <-> our client over real HTTP."""
+
+    def test_roundtrip_single_and_parallel(self, ours_server, payload_file):
+        base_url, _ = ours_server
+        seen: list[str] = []
+        client = TusClient(
+            base_url,
+            chunk_size=256 * 1024,
+            add_request_id=True,
+            on_upload_url_available=seen.append,
+        )
+
+        url = client.upload_file(payload_file)
+        assert seen == [url]
+        info = client.get_upload_info(url)
+        assert info["offset"] == len(PAYLOAD)
+        assert info["complete"] is True
+        assert _download_sha(url) == PAYLOAD_SHA
+
+        purl = client.upload_file(payload_file, parallel_uploads=3)
+        assert seen[-1] == purl
+        assert _download_sha(purl) == PAYLOAD_SHA
+
+
+@pytest.mark.skipif(not TUSD_BIN, reason="tusd binary not found (set TUSD_BIN or add to PATH)")
+class TestClientAgainstTusd:
+    """our client <-> a real tusd server."""
+
+    @pytest.fixture
+    def tusd_server(self, tmp_path):
+        port = _free_port()
+        proc = subprocess.Popen(
+            [
+                TUSD_BIN,
+                "-host",
+                "127.0.0.1",
+                "-port",
+                str(port),
+                "-upload-dir",
+                str(tmp_path / "tusd-data"),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        base = f"http://127.0.0.1:{port}/files/"
+        try:
+            _wait_until_up(base)
+            yield base
+        finally:
+            proc.terminate()
+            proc.wait(timeout=10)
+
+    def test_single_upload(self, tusd_server, payload_file):
+        client = TusClient(tusd_server, chunk_size=256 * 1024, checksum=False)
+        url = client.upload_file(payload_file, metadata={"filename": "ours.bin"})
+        info = client.get_upload_info(url)
+        assert info["offset"] == len(PAYLOAD)
+        assert info["complete"] is True
+        assert _download_sha(url) == PAYLOAD_SHA  # tusd serves GET downloads
+
+    def test_parallel_concatenation(self, tusd_server, payload_file):
+        seen: list[str] = []
+        client = TusClient(
+            tusd_server,
+            chunk_size=256 * 1024,
+            checksum=False,
+            on_upload_url_available=seen.append,
+        )
+        url = client.upload_file(payload_file, parallel_uploads=3)
+        assert seen == [url]
+        assert _download_sha(url) == PAYLOAD_SHA
+
+    def test_server_info(self, tusd_server):
+        client = TusClient(tusd_server, checksum=False)
+        info = client.get_server_info()
+        assert "creation" in info["extensions"]
+        assert "concatenation" in info["extensions"]
+
+    def test_termination(self, tusd_server, payload_file):
+        # tusd advertises the termination extension — our client's DELETE
+        # must remove the upload wire-side.
+        client = TusClient(tusd_server, chunk_size=256 * 1024, checksum=False)
+        url = client.upload_file(payload_file, metadata={"filename": "ours.bin"})
+        client.delete_upload(url)
+        req = urllib.request.Request(url, method="HEAD", headers={"Tus-Resumable": "1.0.0"})
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            urllib.request.urlopen(req)
+        assert exc.value.code == 404
+
+    # Skipped for tusd: it advertises neither the checksum nor the expiration
+    # extension (get_server_info().extensions has no 'checksum'/'expiration'),
+    # so there is nothing on the tusd side to interop against for those.
+
+
+@pytest.mark.skipif(
+    not (NODE_BIN and HAS_TUS_JS),
+    reason="node or tus-js-client missing (run: npm install in tests/interop)",
+)
+class TestServerAgainstTusJs:
+    """our server <-> the real tus-js-client (Node)."""
+
+    def _run_lane3(self, base_url, mode):
+        # The script lives inside tests/interop/ so ESM resolution finds the
+        # node_modules installed next to it (NODE_PATH is ignored for ESM).
+        return subprocess.run(
+            [
+                NODE_BIN,
+                os.path.join(INTEROP_DIR, "tus_js_client.mjs"),
+                base_url,
+                str(len(PAYLOAD)),
+                mode,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+
+    def test_js_upload_head_download(self, ours_server):
+        base_url, _ = ours_server
+        result = self._run_lane3(base_url, "roundtrip")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.startswith("OK ")
+
+    def test_js_termination(self, ours_server):
+        # tus-js-client abort(true) issues the termination DELETE; our server
+        # must then 404 the upload.
+        base_url, _ = ours_server
+        result = self._run_lane3(base_url, "terminate")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.startswith("OK terminated ")
+
+
+@pytest.mark.skipif(
+    not HAS_TUS_PY,
+    reason="tus-py-client missing (pip install tuspy)",
+)
+class TestServerAgainstTusPy:
+    """our server <-> tus-py-client (official Python reference client).
+
+    tusd ships no client binary, so the second reference client that
+    exercises our *server* is the tus project's Python client.
+    """
+
+    def test_py_client_upload_and_download(self, ours_server, payload_file):
+        base_url, _ = ours_server
+        tc = tuspy_client.TusClient(base_url + "/")
+        uploader = tc.uploader(
+            payload_file,
+            chunk_size=256 * 1024,
+            metadata={"filename": "interop.bin"},
+        )
+        uploader.upload()
+        url = uploader.url
+        assert _download_sha(url) == PAYLOAD_SHA
+
+    def test_py_client_resume_after_partial(self, ours_server, payload_file):
+        # Resume is TUS's whole point: upload one chunk, drop the uploader,
+        # then a fresh uploader must continue from the server's offset.
+        base_url, _ = ours_server
+        tc = tuspy_client.TusClient(base_url + "/")
+        first = tc.uploader(payload_file, chunk_size=256 * 1024)
+        first.upload_chunk()  # exactly one chunk
+        assert 0 < first.offset < len(PAYLOAD)
+
+        resumed = tc.uploader(payload_file, url=first.url, chunk_size=256 * 1024)
+        resumed.upload()
+        assert _download_sha(first.url) == PAYLOAD_SHA
+
+    def test_py_client_checksum(self, ours_server, payload_file):
+        # tus-py-client sends `Upload-Checksum: sha1 <b64>` per chunk when
+        # upload_checksum=True; our server verifies it (checksum extension).
+        base_url, _ = ours_server
+        tc = tuspy_client.TusClient(base_url + "/")
+        uploader = tc.uploader(
+            payload_file,
+            chunk_size=256 * 1024,
+            metadata={"filename": "sum.bin"},
+            upload_checksum=True,
+        )
+        uploader.upload()
+        assert _download_sha(uploader.url) == PAYLOAD_SHA
+
+    # Termination is skipped for this lane: tus-py-client exposes no
+    # delete/terminate call, so there is nothing client-side to drive it.

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -70,6 +70,17 @@ def _download_sha(url: str) -> str:
         return hashlib.sha256(resp.read()).hexdigest()
 
 
+def _download(url: str) -> tuple[bytes, dict[str, str]]:
+    with urllib.request.urlopen(url) as resp:
+        return resp.read(), dict(resp.headers)
+
+
+def _write(tmp_path, name: str, data: bytes) -> str:
+    p = tmp_path / name
+    p.write_bytes(data)
+    return str(p)
+
+
 @pytest.fixture
 def ours_server():
     """resumable-upload TusServer over real HTTP; yields (base_url, storage)."""
@@ -132,6 +143,68 @@ class TestNativeRoundTrip:
         purl = client.upload_file(payload_file, parallel_uploads=3)
         assert seen[-1] == purl
         assert _download_sha(purl) == PAYLOAD_SHA
+
+    def test_metadata_roundtrip(self, ours_server, tmp_path):
+        base_url, _ = ours_server
+        path = _write(tmp_path, "doc.bin", b"hello")
+        client = TusClient(base_url, chunk_size=256 * 1024)
+        url = client.upload_file(path, metadata={"filename": "wîndé.txt", "filetype": "text/plain"})
+        meta = client.get_metadata(url)
+        assert meta["filename"] == "wîndé.txt"
+        assert meta["filetype"] == "text/plain"
+        _, headers = _download(url)
+        assert headers["Content-Type"] == "text/plain"
+        assert "attachment" in headers["Content-Disposition"]
+
+    def test_small_chunk_many_requests(self, ours_server, payload_file):
+        base_url, _ = ours_server
+        client = TusClient(base_url, chunk_size=64 * 1024)  # ~33 PATCHes for 2 MB
+        url = client.upload_file(payload_file)
+        assert _download_sha(url) == PAYLOAD_SHA
+
+    def test_resume_after_interruption(self, ours_server, payload_file):
+        base_url, _ = ours_server
+        client = TusClient(base_url, chunk_size=256 * 1024)
+        url = client.upload_file(payload_file, stop_at=512 * 1024)  # stop partway
+        assert 0 < client.get_upload_info(url)["offset"] < len(PAYLOAD)
+        client.resume_upload(payload_file, url)
+        assert _download_sha(url) == PAYLOAD_SHA
+
+    def test_empty_file(self, ours_server, tmp_path):
+        base_url, _ = ours_server
+        path = _write(tmp_path, "empty.bin", b"")
+        client = TusClient(base_url, chunk_size=256 * 1024)
+        url = client.upload_file(path)
+        assert client.get_upload_info(url)["complete"] is True
+        assert _download(url)[0] == b""
+
+    def test_deferred_length(self, ours_server, payload_file):
+        base_url, _ = ours_server
+        client = TusClient(base_url, chunk_size=256 * 1024)
+        url = client.create_deferred_upload(metadata={"filename": "later.bin"})
+        client.resume_upload(payload_file, url)
+        info = client.get_upload_info(url)
+        assert info["complete"] is True
+        assert info["length"] == len(PAYLOAD)
+        assert _download_sha(url) == PAYLOAD_SHA
+
+    def test_single_byte(self, ours_server, tmp_path):
+        # Smallest non-empty payload; exercises exact offset==length boundary.
+        base_url, _ = ours_server
+        path = _write(tmp_path, "one.bin", b"\x00")
+        client = TusClient(base_url, chunk_size=256 * 1024)
+        url = client.upload_file(path)
+        assert client.get_upload_info(url)["complete"] is True
+        assert _download(url)[0] == b"\x00"
+
+    def test_chunk_size_equals_file_size(self, ours_server, tmp_path):
+        # A single PATCH covering the whole file (boundary: one exact chunk).
+        base_url, _ = ours_server
+        data = os.urandom(4096)
+        path = _write(tmp_path, "exact.bin", data)
+        client = TusClient(base_url, chunk_size=4096)
+        url = client.upload_file(path)
+        assert _download(url)[0] == data
 
 
 @pytest.mark.skipif(not TUSD_BIN, reason="tusd binary not found (set TUSD_BIN or add to PATH)")
@@ -199,6 +272,46 @@ class TestClientAgainstTusd:
             urllib.request.urlopen(req)
         assert exc.value.code == 404
 
+    def test_metadata_roundtrip(self, tusd_server, tmp_path):
+        client = TusClient(tusd_server, chunk_size=256 * 1024, checksum=False)
+        path = _write(tmp_path, "m.bin", b"hello")
+        url = client.upload_file(path, metadata={"filename": "wîndé.bin", "filetype": "image/png"})
+        meta = client.get_metadata(url)
+        assert meta["filename"] == "wîndé.bin"
+        assert meta["filetype"] == "image/png"
+
+    def test_small_chunk_many_requests(self, tusd_server, payload_file):
+        client = TusClient(tusd_server, chunk_size=64 * 1024, checksum=False)
+        url = client.upload_file(payload_file, metadata={"filename": "ours.bin"})
+        assert _download_sha(url) == PAYLOAD_SHA
+
+    def test_resume_after_interruption(self, tusd_server, payload_file):
+        client = TusClient(tusd_server, chunk_size=256 * 1024, checksum=False)
+        url = client.upload_file(
+            payload_file, metadata={"filename": "ours.bin"}, stop_at=512 * 1024
+        )
+        assert 0 < client.get_upload_info(url)["offset"] < len(PAYLOAD)
+        client.resume_upload(payload_file, url)
+        assert _download_sha(url) == PAYLOAD_SHA
+
+    def test_empty_file(self, tusd_server, tmp_path):
+        client = TusClient(tusd_server, chunk_size=256 * 1024, checksum=False)
+        path = _write(tmp_path, "empty.bin", b"")
+        url = client.upload_file(path)
+        assert client.get_upload_info(url)["complete"] is True
+        assert _download(url)[0] == b""
+
+    def test_deferred_length(self, tusd_server, payload_file):
+        # tusd advertises creation-defer-length; our client must commit the
+        # length on the first PATCH.
+        client = TusClient(tusd_server, chunk_size=256 * 1024, checksum=False)
+        url = client.create_deferred_upload(metadata={"filename": "later.bin"})
+        client.resume_upload(payload_file, url)
+        info = client.get_upload_info(url)
+        assert info["complete"] is True
+        assert info["length"] == len(PAYLOAD)
+        assert _download_sha(url) == PAYLOAD_SHA
+
     # Skipped for tusd: it advertises neither the checksum nor the expiration
     # extension (get_server_info().extensions has no 'checksum'/'expiration'),
     # so there is nothing on the tusd side to interop against for those.
@@ -240,6 +353,30 @@ class TestServerAgainstTusJs:
         result = self._run_lane3(base_url, "terminate")
         assert result.returncode == 0, result.stderr
         assert result.stdout.startswith("OK terminated ")
+
+    def test_js_empty_file(self, ours_server):
+        base_url, _ = ours_server
+        result = self._run_lane3(base_url, "empty")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.startswith("OK empty ")
+
+    def test_js_metadata_roundtrip(self, ours_server):
+        base_url, _ = ours_server
+        result = self._run_lane3(base_url, "metadata")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.startswith("OK metadata ")
+
+    def test_js_small_chunk(self, ours_server):
+        base_url, _ = ours_server
+        result = self._run_lane3(base_url, "smallchunk")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.startswith("OK smallchunk ")
+
+    def test_js_resume(self, ours_server):
+        base_url, _ = ours_server
+        result = self._run_lane3(base_url, "resume")
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.startswith("OK resume ")
 
 
 @pytest.mark.skipif(
@@ -291,6 +428,48 @@ class TestServerAgainstTusPy:
         )
         uploader.upload()
         assert _download_sha(uploader.url) == PAYLOAD_SHA
+
+    def test_py_client_empty_file(self, ours_server, tmp_path):
+        # A real client's 0-byte upload must complete and download empty.
+        base_url, _ = ours_server
+        path = _write(tmp_path, "empty.bin", b"")
+        tc = tuspy_client.TusClient(base_url + "/")
+        uploader = tc.uploader(path, chunk_size=256 * 1024)
+        uploader.upload()
+        assert _download(uploader.url)[0] == b""
+
+    def test_py_client_metadata_roundtrip(self, ours_server, tmp_path):
+        base_url, _ = ours_server
+        path = _write(tmp_path, "m.bin", b"hello")
+        tc = tuspy_client.TusClient(base_url + "/")
+        uploader = tc.uploader(
+            path,
+            chunk_size=256 * 1024,
+            metadata={"filename": "wîndé.txt", "filetype": "text/plain"},
+        )
+        uploader.upload()
+        _, headers = _download(uploader.url)
+        assert headers["Content-Type"] == "text/plain"
+        assert "attachment" in headers["Content-Disposition"]
+
+    def test_py_client_small_chunk(self, ours_server, payload_file):
+        base_url, _ = ours_server
+        tc = tuspy_client.TusClient(base_url + "/")
+        uploader = tc.uploader(payload_file, chunk_size=64 * 1024)  # many PATCHes
+        uploader.upload()
+        assert _download_sha(uploader.url) == PAYLOAD_SHA
+
+    def test_py_client_unicode_filename_download(self, ours_server, tmp_path):
+        # Non-Latin-1 filename must survive to the download's RFC 5987 header.
+        base_url, _ = ours_server
+        path = _write(tmp_path, "u.bin", b"data")
+        tc = tuspy_client.TusClient(base_url + "/")
+        uploader = tc.uploader(path, chunk_size=256 * 1024, metadata={"filename": "파일.bin"})
+        uploader.upload()
+        _, headers = _download(uploader.url)
+        disp = headers["Content-Disposition"]
+        assert "filename*=UTF-8''" in disp  # RFC 5987 encoded form
+        assert "%ED%8C%8C" in disp  # percent-encoded '파'
 
     # Termination is skipped for this lane: tus-py-client exposes no
     # delete/terminate call, so there is nothing client-side to drive it.


### PR DESCRIPTION
## Purpose

Reproducible interop suite (`make interop`), 4 local lanes. Stacked on `feat/proxy-location`.

- ours↔ours, tusd↔our-client, our-server↔tus-js-client, our-server↔tus-py-client
- auto-provisions latest tusd binary for host OS/arch
- broadened scenarios: empty files, metadata, resume, deferred length, unicode, chunk boundaries
- README documents the lanes

## Test Plan

- `make interop`

## Test Result

- 30 interop cases pass across all 4 lanes

---

<details>
<summary>Checklist</summary>

- [x] PR title follows Conventional Commits (`type(scope): ...`)
- [x] `pytest -v` passes locally
- [x] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [x] Tests added for new behavior or regression
- [x] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
