### PR TITLE
chore(release): derive version from git tag via setuptools-scm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0  # setuptools-scm needs full history + tags to derive the version
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,112 +1,16 @@
 # Changelog
 
-All notable changes to this project are documented here. The format follows
-[Keep a Changelog](https://keepachangelog.com/), and this project adheres to
-[Semantic Versioning](https://semver.org/).
+Release notes live on **GitHub Releases**, generated automatically from the
+pull requests merged since the previous tag:
 
-## [Unreleased]
+### 👉 https://github.com/injaeryou/resumable-upload/releases
 
-### Added
+Each release page groups the changes by category (features, fixes, docs,
+maintenance). To install a specific version:
 
-- **`concatenation-unfinished` extension** (SQLite backend): POST a final
-  upload while its partials are still in progress. The final stays *pending*
-  (no offset/length) until the last partial completes, then assembles
-  atomically and fires `on_upload_complete`. Advertised only when the storage
-  backend sets `supports_unfinished_concat`.
+```bash
+pip install "resumable-upload==<version>"
+```
 
-- **`checksum-trailer` extension**: `Upload-Checksum` is accepted as an HTTP
-  trailer on chunked requests. The bundled `TusHTTPRequestHandler` (and the
-  `serve` CLI) parses chunked bodies + trailers; other transports opt in via
-  `TusServer(supports_checksum_trailer=True)` after doing the same.
-
-- **Opt-in GET download endpoint** (tusd-style): `TusServer(enable_downloads=True)`
-  or `serve --enable-downloads` serves completed uploads over GET. Safe by
-  default: always `Content-Disposition: attachment`, sanitized filename,
-  validated `Content-Type` from metadata `filetype`; incomplete uploads `404`,
-  expired `410`.
-
-- **Client ergonomics** (sync + async): `override_patch_method` (tunnel PATCH
-  through POST + `X-HTTP-Method-Override`), `add_request_id` (unique
-  `X-Request-ID` per request), `on_upload_url_available` callback, and
-  `metadata_for_partial_uploads` for parallel uploads.
-
-- **Expanded server hooks to tusd parity**: `on_chunk_received` (per-chunk
-  progress; raise `TusHookError` to stop and delete the upload mid-flight),
-  `on_upload_complete` may return `{status_code, headers, body}` to customize
-  the finishing response, `on_before_terminate` can veto client DELETEs, and
-  `TusServer.terminate_upload()` terminates out-of-band.
-
-- **CORS depth**: `cors_allow_origins` accepts an origin list (matched and
-  echoed with `Vary: Origin`), plus `cors_allow_credentials` and
-  `cors_max_age`. Wildcard + credentials safely echoes the request origin.
-
-- **Absolute `Location` options**: `behind_proxy=True` honors
-  `X-Forwarded-Proto`/`X-Forwarded-Host` (tusd's `-behind-proxy`);
-  `location_base_url` sets a fixed prefix. Relative Location remains the
-  default.
-
-- **Feature toggles** (tusd-style): `disable_termination` (client DELETE →
-  `405`) and `disable_concatenation` (`Upload-Concat` → `400`), both dropped
-  from `Tus-Extension` advertisement and available as `serve` flags.
-
-### Fixed
-
-- **`Upload-Metadata` key rules enforced**: duplicate keys and non-ASCII keys
-  now return `400` as the spec requires (previously last-write-wins /
-  silently accepted). Bare keys keep working.
-- **HEAD on a final upload now echoes `Upload-Concat: final;<urls>`** as the
-  spec requires. Source partial ids are persisted on the final upload record
-  (`concat_partial_ids`) across all four storage backends; existing SQLite
-  databases migrate automatically.
-
-## [0.1.0] - 2026-06-25
-
-Async support on **both** sides of the protocol, with the core install
-staying zero-dependency.
-
-### Added
-
-- **Async client** behind the new `[async]` extra (`pip install "resumable-upload[async]"`, httpx):
-  `AsyncTusClient` and `AsyncUploader` — a full async counterpart to
-  `TusClient` / `Uploader`. Every method has an awaitable equivalent: upload,
-  resume, delete, protocol queries (`get_upload_info` / `get_metadata` /
-  `get_server_info`), concatenation (`create_partial_upload` /
-  `create_final_upload`), `parallel_uploads=N`, deferred-length, checksums,
-  retries, and 409 re-sync. `httpx` is imported lazily, so `import
-  resumable_upload` never pulls it in.
-- **Async server**: `TusServer.handle_request_async`, and `TusASGIApp` now
-  awaits it directly. New `Storage.*_async` surface — sync backends inherit
-  `asyncio.to_thread` wrappers automatically; true-async backends override
-  only the methods they have native implementations for. See
-  `examples/server/async_storage.py` for a native-async backend template.
-- HEAD on a partial upload now echoes `Upload-Concat: partial`
-  (concatenation-extension conformance).
-- New runnable examples: `examples/client/async_upload.py` and
-  `examples/server/async_storage.py`, both smoke-tested.
-
-### Changed
-
-- Internal refactor: the sync and async paths share one source of truth for
-  all protocol rules — server validators (`_plan_*`) and the client's pure
-  helpers (`resumable_upload/client/_protocol.py`) — so the two paths cannot
-  drift on the wire. No public API change.
-- Checksum coverage verified across `sha1` / `sha256` / `sha512` / `md5` on
-  both dispatch paths.
-- Project URLs updated to the `injaeryou` GitHub owner.
-- Deprecated top-level import aliases (`storage_s3` / `storage_gcs` /
-  `storage_azure` / `locks_redis` / `client.base`) are now scheduled for
-  removal **after 0.1.2** (previously 0.0.8 / 0.1.0).
-
-### Compatibility
-
-- No breaking changes. `httpx` is required only by the `[async]` extra.
-- Tested on Python 3.9 – 3.14. Wire-compatible with tus-js-client, tusd,
-  uppy, and tus-py-client.
-
-### Known limitations
-
-- HEAD on a **final** concatenated upload does not yet echo
-  `Upload-Concat: final;<urls>` (informational only; finals complete on POST,
-  so `Upload-Offset` / `Upload-Length` are correct). See `docs/compliance.md`.
-
-[0.1.0]: https://github.com/injaeryou/resumable-upload/releases/tag/v0.1.0
+Versions follow [Semantic Versioning](https://semver.org/) and are derived
+from the git tag at build time (`setuptools-scm`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ up or note why it doesn't apply:
 - [ ] **server / client** — the core implementation + its sync **and** async paths
 - [ ] **CLI** — in `cli.py`: a `serve` flag (+ `_serve` wiring) for a server option a deployer sets, or an `upload`/`download`/`info` subcommand/flag for a client capability
 - [ ] **docs** — every surface that describes the feature: the `docs/` mkdocs pages (usage/API/operations, incl. `docs/operations/cli.md`), the README (feature list, extension/compliance table, API-reference links, CLI section), and `TUS_COMPLIANCE.md` when it touches the wire protocol. Keep `README.ko.md` in sync with `README.md`.
-- [ ] **CHANGELOG** — an entry under `## [Unreleased]` in `CHANGELOG.md` (Added/Changed/Fixed) for any user-visible change
+- [ ] **release notes** — no manual `CHANGELOG.md`; notes are auto-generated on GitHub Releases from merged PRs. For any user-visible change, make sure the **PR title** is a clear Conventional-Commits summary so it reads well in the generated notes
 - [ ] **tests** — unit coverage on both sync and async surfaces
 - [ ] **interop** — a `tests/test_interop.py` case when it touches the wire protocol and a counterpart (tusd / tus-js-client / tus-py-client) supports it
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -51,8 +51,10 @@ from resumable_upload import TusServer, TusHTTPRequestHandler, SQLiteStorage
 storage = SQLiteStorage(db_path="uploads.db", upload_dir="uploads")
 tus_server = TusServer(storage=storage, base_path="/files")
 
+
 class Handler(TusHTTPRequestHandler):
     pass
+
 
 Handler.tus_server = tus_server
 server = HTTPServer(("0.0.0.0", 8080), Handler)
@@ -65,16 +67,18 @@ server.serve_forever()
 ```python
 from resumable_upload import TusClient, UploadStats
 
+
 def progress(stats: UploadStats):
-    print(f"진행률: {stats.progress_percent:.1f}% | "
-          f"{stats.uploaded_bytes}/{stats.total_bytes} 바이트 | "
-          f"속도: {stats.upload_speed_mbps:.2f} MB/s")
+    print(
+        f"진행률: {stats.progress_percent:.1f}% | "
+        f"{stats.uploaded_bytes}/{stats.total_bytes} 바이트 | "
+        f"속도: {stats.upload_speed_mbps:.2f} MB/s"
+    )
+
 
 client = TusClient("http://localhost:8080/files")
 upload_url = client.upload_file(
-    "large_file.bin",
-    metadata={"filename": "large_file.bin"},
-    progress_callback=progress
+    "large_file.bin", metadata={"filename": "large_file.bin"}, progress_callback=progress
 )
 print(f"업로드 완료: {upload_url}")
 ```
@@ -86,9 +90,11 @@ print(f"업로드 완료: {upload_url}")
 import asyncio
 from resumable_upload import AsyncTusClient
 
+
 async def main():
     async with AsyncTusClient("http://localhost:8080/files") as client:
         url = await client.upload_file("large_file.bin")
+
 
 asyncio.run(main())
 ```
@@ -114,9 +120,17 @@ TusClient("...", checksum="sha256")
 관측/재시도 세밀 제어:
 
 ```python
-def before(method, url, headers): print(f"-> {method} {url}")
-def after(method, url, status):   print(f"<- {method} {status}")
-def should_retry(err, attempt):   return not isinstance(err, PermissionError)
+def before(method, url, headers):
+    print(f"-> {method} {url}")
+
+
+def after(method, url, status):
+    print(f"<- {method} {status}")
+
+
+def should_retry(err, attempt):
+    return not isinstance(err, PermissionError)
+
 
 client = TusClient(
     "...",

--- a/README.md
+++ b/README.md
@@ -57,9 +57,11 @@ storage = SQLiteStorage(db_path="uploads.db", upload_dir="uploads")
 # Create TUS server
 tus_server = TusServer(storage=storage, base_path="/files")
 
+
 # Create HTTP handler
 class Handler(TusHTTPRequestHandler):
     pass
+
 
 Handler.tus_server = tus_server
 
@@ -80,15 +82,17 @@ client = TusClient("http://localhost:8080/files")
 # Upload file with progress callback
 from resumable_upload import UploadStats
 
+
 def progress(stats: UploadStats):
-    print(f"Progress: {stats.progress_percent:.1f}% | "
-          f"{stats.uploaded_bytes}/{stats.total_bytes} bytes | "
-          f"Speed: {stats.upload_speed_mbps:.2f} MB/s")
+    print(
+        f"Progress: {stats.progress_percent:.1f}% | "
+        f"{stats.uploaded_bytes}/{stats.total_bytes} bytes | "
+        f"Speed: {stats.upload_speed_mbps:.2f} MB/s"
+    )
+
 
 upload_url = client.upload_file(
-    "large_file.bin",
-    metadata={"filename": "large_file.bin"},
-    progress_callback=progress
+    "large_file.bin", metadata={"filename": "large_file.bin"}, progress_callback=progress
 )
 
 print(f"Upload complete: {upload_url}")
@@ -101,9 +105,11 @@ print(f"Upload complete: {upload_url}")
 import asyncio
 from resumable_upload import AsyncTusClient
 
+
 async def main():
     async with AsyncTusClient("http://localhost:8080/files") as client:
         url = await client.upload_file("large_file.bin")
+
 
 asyncio.run(main())
 ```
@@ -129,9 +135,17 @@ TusClient("...", checksum="sha256")
 Observability + domain-specific retry gating:
 
 ```python
-def before(method, url, headers): print(f"-> {method} {url}")
-def after(method, url, status):   print(f"<- {method} {status}")
-def should_retry(err, attempt):   return not isinstance(err, PermissionError)
+def before(method, url, headers):
+    print(f"-> {method} {url}")
+
+
+def after(method, url, status):
+    print(f"<- {method} {status}")
+
+
+def should_retry(err, attempt):
+    return not isinstance(err, PermissionError)
+
 
 client = TusClient(
     "...",

--- a/docs/advanced-usage/observability.md
+++ b/docs/advanced-usage/observability.md
@@ -8,8 +8,10 @@
 def before(method, url, headers):
     print(f"-> {method} {url}")
 
+
 def after(method, url, status):
     print(f"<- {method} {url} {status}")
+
 
 client = TusClient(
     "http://localhost:8080/files",
@@ -27,8 +29,9 @@ The hooks are forwarded to any `Uploader` you obtain from `TusClient.create_uplo
 ```python
 def should_retry(err: Exception, attempt: int) -> bool:
     if isinstance(err, PermissionError):
-        return False              # don't retry auth failures
-    return attempt < 5            # cap above the configured max_retries
+        return False  # don't retry auth failures
+    return attempt < 5  # cap above the configured max_retries
+
 
 client = TusClient(
     "http://localhost:8080/files",

--- a/docs/advanced-usage/retry.md
+++ b/docs/advanced-usage/retry.md
@@ -9,7 +9,7 @@ from resumable_upload import TusClient
 
 client = TusClient(
     "http://localhost:8080/files",
-    max_retries=3,    # Retry up to 3 times per chunk (default: 3)
+    max_retries=3,  # Retry up to 3 times per chunk (default: 3)
     retry_delay=1.0,  # Base delay; doubles each attempt, capped at 60s
 )
 ```
@@ -25,16 +25,20 @@ Pass a callback to `upload_file()` to receive `UploadStats` after each chunk:
 ```python
 from resumable_upload import TusClient, UploadStats
 
+
 def progress_callback(stats: UploadStats):
-    print(f"Progress: {stats.progress_percent:.1f}% | "
-          f"Speed: {stats.upload_speed/1024/1024:.2f} MB/s | "
-          f"ETA: {stats.eta_seconds:.0f}s | "
-          f"Chunks: {stats.chunks_completed}/{stats.total_chunks} | "
-          f"Retried: {stats.chunks_retried}")
+    print(
+        f"Progress: {stats.progress_percent:.1f}% | "
+        f"Speed: {stats.upload_speed / 1024 / 1024:.2f} MB/s | "
+        f"ETA: {stats.eta_seconds:.0f}s | "
+        f"Chunks: {stats.chunks_completed}/{stats.total_chunks} | "
+        f"Retried: {stats.chunks_retried}"
+    )
+
 
 client = TusClient(
     "http://localhost:8080/files",
-    chunk_size=1.5*1024*1024,
+    chunk_size=1.5 * 1024 * 1024,
     checksum=True,
 )
 upload_url = client.upload_file(

--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -135,12 +135,15 @@ Create an `Uploader` instance for fine-grained chunk-level control.
 def before(method, url, headers):
     print(f"-> {method} {url}")
 
+
 def after(method, url, status):
     print(f"<- {method} {url} {status}")
+
 
 def should_retry(err, attempt):
     # don't retry permission errors; do retry everything else
     return not isinstance(err, PermissionError)
+
 
 client = TusClient(
     "http://localhost:8080/files",
@@ -219,10 +222,12 @@ importable without it — a helpful `ImportError` is raised if you forget.
 import asyncio
 from resumable_upload import AsyncTusClient
 
+
 async def main():
     async with AsyncTusClient("http://localhost:8080/files") as client:
         url = await client.upload_file("large.bin", progress_callback=print)
         print("Uploaded to", url)
+
 
 asyncio.run(main())
 ```

--- a/docs/api-reference/exceptions.md
+++ b/docs/api-reference/exceptions.md
@@ -3,9 +3,7 @@
 ## Exceptions
 
 ```python
-from resumable_upload.exceptions import (
-    TusCommunicationError, TusUploadFailed, TusHookError
-)
+from resumable_upload.exceptions import TusCommunicationError, TusUploadFailed, TusHookError
 ```
 
 ### Client Exceptions
@@ -73,6 +71,7 @@ Cheap strategy — MD5 of the first `probe_bytes` bytes plus the file size. Matc
 ```python
 def my_fp(file_source) -> str:
     return f"user-42:{file_source}"
+
 
 client = TusClient("...", fingerprinter=CallableFingerprint(my_fp))
 ```

--- a/docs/api-reference/server.md
+++ b/docs/api-reference/server.md
@@ -84,12 +84,15 @@ For out-of-band cancellation there is also `TusServer.terminate_upload(upload_id
 from resumable_upload import TusServer, SQLiteStorage
 from resumable_upload.exceptions import TusHookError
 
+
 def auth_check(method, path, headers):
     if "authorization" not in headers:
         raise TusHookError("Unauthorized", status_code=401)
 
+
 def on_complete(upload_id, metadata, file_info):
     print(f"Upload {upload_id} completed: {file_info}")
+
 
 server = TusServer(
     storage=SQLiteStorage(),
@@ -131,8 +134,10 @@ Async sibling used by `TusASGIApp`. Storage backends that keep the default `*_as
 ```python
 from resumable_upload import TusHTTPRequestHandler
 
+
 class Handler(TusHTTPRequestHandler):
     pass
+
 
 Handler.tus_server = tus_server
 server = HTTPServer(("0.0.0.0", 8080), Handler)

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -41,8 +41,11 @@ Subclass `Storage` to implement a custom backend:
 ```python
 from resumable_upload.storage import Storage
 
+
 class MyStorage(Storage):
-    def create_upload(self, upload_id, upload_length, metadata, expires_at=None, is_partial=False): ...
+    def create_upload(
+        self, upload_id, upload_length, metadata, expires_at=None, is_partial=False
+    ): ...
     def get_upload(self, upload_id): ...
     def update_offset(self, upload_id, offset): ...
     def delete_upload(self, upload_id): ...
@@ -70,8 +73,7 @@ class S3AsyncStorage(S3Storage):
         # native non-blocking upload-part call
         ...
 
-    async def complete_upload_async(self, upload_id):
-        ...
+    async def complete_upload_async(self, upload_id): ...
 
     # everything else inherits the to_thread default
 ```
@@ -91,8 +93,8 @@ from resumable_upload.storage_s3 import S3Storage
 
 storage = S3Storage(
     bucket="my-uploads",
-    prefix="tus",           # optional key prefix
-    part_size=8*1024*1024,  # 8MB (default), min 5MB enforced
+    prefix="tus",  # optional key prefix
+    part_size=8 * 1024 * 1024,  # 8MB (default), min 5MB enforced
 )
 ```
 
@@ -115,7 +117,7 @@ Concatenation is implemented via `UploadPartCopy` so partial-to-final merge happ
 
 ```python
 storage.complete_upload(upload_id)  # Assembles the final S3 object
-data = storage.read_file(upload_id) # Read the completed file
+data = storage.read_file(upload_id)  # Read the completed file
 info = storage.get_file_info(upload_id)
 # {"upload_id": "...", "bucket": "my-uploads", "key": "tus/abc123"}
 ```
@@ -132,7 +134,7 @@ from resumable_upload.storage_gcs import GCSStorage
 storage = GCSStorage(
     bucket="my-uploads",
     prefix="tus",
-    part_size=8*1024*1024,
+    part_size=8 * 1024 * 1024,
 )
 ```
 
@@ -168,7 +170,7 @@ storage = AzureBlobStorage(
     container="my-uploads",
     connection_string="DefaultEndpointsProtocol=https;...",
     prefix="tus",
-    part_size=8*1024*1024,
+    part_size=8 * 1024 * 1024,
 )
 ```
 
@@ -204,6 +206,7 @@ JSON file-based URL storage for cross-session resumability.
 
 ```python
 from resumable_upload import FileURLStorage
+
 storage = FileURLStorage(".tus_urls.json")
 ```
 
@@ -221,6 +224,7 @@ SQLite-backed URL storage. Preferred over `FileURLStorage` for multi-process cli
 
 ```python
 from resumable_upload import SQLiteURLStorage
+
 storage = SQLiteURLStorage("tus_urls.db")
 ```
 
@@ -235,6 +239,7 @@ Fast, process-local URL storage. Everything is forgotten when the process exits 
 
 ```python
 from resumable_upload import InMemoryURLStorage
+
 storage = InMemoryURLStorage()
 ```
 
@@ -242,6 +247,7 @@ storage = InMemoryURLStorage()
 
 ```python
 from resumable_upload.url_storage import URLStorage
+
 
 class MyURLStorage(URLStorage):
     def get_url(self, fingerprint: str) -> str | None: ...

--- a/docs/index.md
+++ b/docs/index.md
@@ -58,8 +58,10 @@ from resumable_upload import TusServer, TusHTTPRequestHandler, SQLiteStorage
 storage = SQLiteStorage(db_path="uploads.db", upload_dir="uploads")
 tus_server = TusServer(storage=storage, base_path="/files")
 
+
 class Handler(TusHTTPRequestHandler):
     pass
+
 
 Handler.tus_server = tus_server
 server = HTTPServer(("0.0.0.0", 8080), Handler)
@@ -80,9 +82,10 @@ See [CLI](operations/cli.md) for all flags.
 ```python
 from resumable_upload import TusClient, UploadStats
 
+
 def progress(stats: UploadStats):
-    print(f"Progress: {stats.progress_percent:.1f}% | "
-          f"Speed: {stats.upload_speed_mbps:.2f} MB/s")
+    print(f"Progress: {stats.progress_percent:.1f}% | Speed: {stats.upload_speed_mbps:.2f} MB/s")
+
 
 client = TusClient("http://localhost:8080/files")
 upload_url = client.upload_file(

--- a/docs/operations/locks.md
+++ b/docs/operations/locks.md
@@ -11,8 +11,8 @@ from resumable_upload.locks import InMemoryLockBackend
 server = TusServer(
     storage=SQLiteStorage(),
     lock_backend=InMemoryLockBackend(),
-    lock_ttl_seconds=60.0,   # auto-release if the holder crashes
-    lock_wait_seconds=5.0,   # 423 Locked when contention exceeds this
+    lock_ttl_seconds=60.0,  # auto-release if the holder crashes
+    lock_wait_seconds=5.0,  # 423 Locked when contention exceeds this
 )
 ```
 
@@ -55,6 +55,7 @@ Subclass `LockBackend` to plug in an alternative coordinator (Zookeeper, etcd, P
 
 ```python
 from resumable_upload.locks import LockBackend
+
 
 class MyLockBackend(LockBackend):
     def acquire(self, key: str, ttl_seconds: float, wait_timeout: float = 0.0) -> str | None:

--- a/docs/web-frameworks/django.md
+++ b/docs/web-frameworks/django.md
@@ -7,10 +7,14 @@ from resumable_upload import TusServer, SQLiteStorage
 
 tus_server = TusServer(storage=SQLiteStorage())
 
+
 @csrf_exempt
 def tus_upload_view(request, upload_id=None):
-    headers = {key[5:].replace('_', '-'): value
-               for key, value in request.META.items() if key.startswith('HTTP_')}
+    headers = {
+        key[5:].replace("_", "-"): value
+        for key, value in request.META.items()
+        if key.startswith("HTTP_")
+    }
     status, response_headers, response_body = tus_server.handle_request(
         request.method, request.path, headers, request.body
     )
@@ -28,8 +32,8 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('files/', views.tus_upload_view),
-    path('files/<str:upload_id>/', views.tus_upload_view),
+    path("files/", views.tus_upload_view),
+    path("files/<str:upload_id>/", views.tus_upload_view),
 ]
 ```
 

--- a/docs/web-frameworks/fastapi.md
+++ b/docs/web-frameworks/fastapi.md
@@ -29,6 +29,7 @@ from resumable_upload import TusServer, SQLiteStorage
 app = FastAPI()
 tus_server = TusServer(storage=SQLiteStorage())
 
+
 @app.api_route("/files", methods=["OPTIONS", "POST"])
 @app.api_route("/files/{upload_id}", methods=["HEAD", "PATCH", "DELETE"])
 async def handle_upload(request: Request):

--- a/docs/web-frameworks/flask.md
+++ b/docs/web-frameworks/flask.md
@@ -7,8 +7,9 @@ from resumable_upload import TusServer, SQLiteStorage
 app = Flask(__name__)
 tus_server = TusServer(storage=SQLiteStorage())
 
-@app.route('/files', methods=['OPTIONS', 'POST'])
-@app.route('/files/<upload_id>', methods=['HEAD', 'PATCH', 'DELETE'])
+
+@app.route("/files", methods=["OPTIONS", "POST"])
+@app.route("/files/<upload_id>", methods=["HEAD", "PATCH", "DELETE"])
 def handle_upload(upload_id=None):
     status, headers, body = tus_server.handle_request(
         request.method, request.path, dict(request.headers), request.get_data()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "resumable-upload"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A Python implementation of the `TUS resumable upload protocol` for server and client, with zero runtime dependencies."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -28,14 +28,13 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
 ]
-dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/injaeryou/resumable-upload"
 Documentation = "https://injaeryou.github.io/resumable-upload/"
 Repository = "https://github.com/injaeryou/resumable-upload"
 Issues = "https://github.com/injaeryou/resumable-upload/issues"
-Changelog = "https://github.com/injaeryou/resumable-upload/blob/main/CHANGELOG.md"
+Changelog = "https://github.com/injaeryou/resumable-upload/releases"
 Releases = "https://github.com/injaeryou/resumable-upload/releases"
 
 [project.scripts]
@@ -91,6 +90,9 @@ docs = [
     "mkdocs-git-revision-date-localized-plugin>=1.2",
 ]
 
+[tool.setuptools_scm]
+fallback_version = "0.0.0+unknown"
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
@@ -129,6 +131,9 @@ ignore = [
     # f-string format
     "UP032",
 ]
+
+[tool.ruff.lint.per-file-ignores]
+"resumable_upload/__init__.py" = ["E402", "I001"]
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/resumable_upload/__init__.py
+++ b/resumable_upload/__init__.py
@@ -4,7 +4,15 @@ A Python implementation of the TUS resumable upload protocol.
 Provides both server and client components with minimal dependencies.
 """
 
-__version__ = "0.0.5"
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
+
+# Version comes from the git tag at build time (setuptools-scm); read it back
+# from the installed package metadata so the two can never drift.
+try:
+    __version__ = _pkg_version("resumable-upload")
+except PackageNotFoundError:  # not installed (e.g. running from a source tree)
+    __version__ = "0.0.0+unknown"
+del _pkg_version, PackageNotFoundError
 
 from resumable_upload.client import TusClient, Uploader, UploadStats
 from resumable_upload.exceptions import TusCommunicationError, TusHookError, TusUploadFailed


### PR DESCRIPTION
## Changes
- Version is derived from the git tag at build time via `setuptools-scm`; `resumable_upload.__version__` reads it back from installed metadata. Removes the hardcoded `version` / `__version__` that had drifted (`__version__` was `0.0.5` while the package shipped `0.1.0`).
- Release notes move to GitHub Releases' auto-generation; `CHANGELOG.md` becomes a pointer to the Releases page.
- `publish.yml`: `fetch-depth: 0` so setuptools-scm can see tags.
- Feature-surface checklist in `CLAUDE.md` updated to the new flow.
- Reformats embedded code blocks in 13 docs (README + `docs/**`) with ruff 0.16, which CI installs; no source-code changes.

## Release flow (after merge)
Create a GitHub Release with a `vX.Y.Z` tag → `publish.yml` builds and uploads to PyPI. No manual version bump.

## Test Plan / Result
- `pytest` → 654 passed, 26 skipped
- ruff 0.16 `check .` / `format --check .` → clean; `ty check` → clean
- Simulated `v0.1.1` tag build → wheel `resumable_upload-0.1.1-...whl`, runtime `__version__ == 0.1.1`