### PR TITLE
build: add [all] extra installing every optional feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,7 @@ Out-of-band: `TusServer.terminate_upload(upload_id)` deletes + fires the post-ho
 
 ```bash
 # Install for development
-uv pip install -e ".[dev,test,all-storage]"
+uv pip install -e ".[dev,test,all]"
 
 # Run all tests with coverage
 pytest --cov=resumable_upload --cov-report=term-missing

--- a/Makefile
+++ b/Makefile
@@ -27,10 +27,10 @@ help:
 
 install:
 	@command -v uv >/dev/null 2>&1 || { echo "Error: uv is not installed. Install it with: curl -LsSf https://astral.sh/uv/install.sh | sh"; exit 1; }
-	uv pip install -e ".[dev,test]"
+	uv pip install -e ".[dev,test,all]"
 
 install-pip:
-	$(PYTHON) -m pip install -e ".[dev,test]"
+	$(PYTHON) -m pip install -e ".[dev,test,all]"
 
 lint:
 	$(RUN) ruff check .

--- a/README.ko.md
+++ b/README.ko.md
@@ -40,6 +40,20 @@ uv pip install resumable-upload
 pip install resumable-upload
 ```
 
+### 선택 extras
+
+코어 설치는 런타임 의존성이 없습니다. 필요한 기능만 골라 설치하세요:
+
+```bash
+pip install "resumable-upload[async]"         # AsyncTusClient (httpx)
+pip install "resumable-upload[s3]"            # AWS S3 스토리지 백엔드
+pip install "resumable-upload[gcs]"           # Google Cloud Storage 백엔드
+pip install "resumable-upload[azure]"         # Azure Blob Storage 백엔드
+pip install "resumable-upload[redis]"         # RedisLockBackend
+pip install "resumable-upload[all-storage]"   # 클라우드 백엔드 전체
+pip install "resumable-upload[all]"           # 선택 기능 전체
+```
+
 ## 🚀 빠른 시작
 
 ### 기본 서버

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ uv pip install resumable-upload
 pip install resumable-upload
 ```
 
+### Optional extras
+
+The core install has zero runtime dependencies. Opt into the features you need:
+
+```bash
+pip install "resumable-upload[async]"         # AsyncTusClient (httpx)
+pip install "resumable-upload[s3]"            # AWS S3 storage backend
+pip install "resumable-upload[gcs]"           # Google Cloud Storage backend
+pip install "resumable-upload[azure]"         # Azure Blob Storage backend
+pip install "resumable-upload[redis]"         # RedisLockBackend
+pip install "resumable-upload[all-storage]"   # All cloud backends
+pip install "resumable-upload[all]"           # Every optional feature
+```
+
 ## 🚀 Quick Start
 
 ### Basic Server

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,11 +40,13 @@ A Python implementation of the [TUS resumable upload protocol](https://tus.io/) 
 ### Optional extras
 
 ```bash
+pip install resumable-upload[async]         # AsyncTusClient (httpx)
 pip install resumable-upload[s3]            # AWS S3 storage backend
 pip install resumable-upload[gcs]           # Google Cloud Storage backend
 pip install resumable-upload[azure]         # Azure Blob Storage backend
 pip install resumable-upload[redis]         # RedisLockBackend
 pip install resumable-upload[all-storage]   # All cloud backends
+pip install resumable-upload[all]           # Every optional feature
 ```
 
 ## Quick Start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,12 @@ all-storage = [
     "google-cloud-storage>=2.0.0",
     "azure-storage-blob>=12.0.0",
 ]
+# Every optional runtime feature. Self-referential so it can never drift from
+# the extras it aggregates; dev/test/docs stay out — installing the library
+# should not pull a test runner.
+all = [
+    "resumable-upload[async,s3,gcs,azure,redis]",
+]
 docs = [
     "mkdocs-material>=9.5,<10",
     "mkdocs>=1.6,<2",

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -1,0 +1,35 @@
+"""The [all] extra must cover every optional runtime feature."""
+
+import re
+from pathlib import Path
+
+_PYPROJECT = (Path(__file__).resolve().parent.parent / "pyproject.toml").read_text()
+
+# Text-based (no tomllib — must pass on the 3.9/3.10 tox envs too).
+_OPTIONAL_DEPS = re.search(r"(?ms)^\[project\.optional-dependencies\]\n(.*?)^\[", _PYPROJECT).group(
+    1
+)
+
+# Extras that exist for tooling or that aggregate other extras, not features.
+_NOT_A_FEATURE = {"dev", "test", "docs", "all", "all-storage"}
+
+
+def _extra(name):
+    m = re.search(rf"(?ms)^{re.escape(name)}\s*=\s*\[(.*?)^\]", _OPTIONAL_DEPS)
+    assert m, f"no [project.optional-dependencies] {name} = [...] block"
+    return m.group(1)
+
+
+def test_all_extra_is_self_referential():
+    # Referencing the extras (rather than restating their pins) is what keeps
+    # [all] from drifting when one of them bumps a version.
+    assert "resumable-upload[" in _extra("all")
+
+
+def test_all_extra_covers_every_feature_extra():
+    names = re.findall(r"(?m)^([a-z][a-z0-9-]*)\s*=\s*\[", _OPTIONAL_DEPS)
+    features = [n for n in names if n not in _NOT_A_FEATURE]
+    assert features, "no feature extras found — regex out of date?"
+    referenced = _extra("all")
+    missing = [n for n in features if not re.search(rf"[\[,]{n}[,\]]", referenced)]
+    assert not missing, f"[all] does not cover: {', '.join(missing)}"


### PR DESCRIPTION
## Purpose

Self-referential `[all]` extra so it can never drift from the extras it aggregates (dev/test/docs stay out), plus the extras table the READMEs were missing.
<!-- What this PR does and why. Link the related issue: "Part of #N" or "Closes #N". -->

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
