### PR TITLE
fix: atomic CAS across cloud backends, async parity, client lifecycle

### DIFF
--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -115,6 +115,8 @@ For small files (all data fits in the buffer), a single `PutObject` is used inst
 
 Concatenation is implemented via `UploadPartCopy` so partial-to-final merge happens entirely on the S3 side.
 
+`update_offset_atomic()` writes the offset back under an `If-Match` on the info object's ETag, so a concurrent writer on another node loses with `412` and gets `False` instead of silently overwriting the winner.
+
 ```python
 storage.complete_upload(upload_id)  # Assembles the final S3 object
 data = storage.read_file(upload_id)  # Read the completed file
@@ -150,6 +152,8 @@ storage = GCSStorage(
 ### How it Works
 
 Chunks are buffered and flushed as individual part blobs. On `complete_upload()`, parts are assembled using GCS `compose()` (handles the 32-object limit via hierarchical composition). For small files, a direct upload is used. Concatenation also uses `compose()`.
+
+`update_offset_atomic()` writes the offset back with `if_generation_match`, so a concurrent writer on another node loses with `412` and gets `False` instead of silently overwriting the winner.
 
 ```python
 storage.complete_upload(upload_id)
@@ -187,6 +191,8 @@ storage = AzureBlobStorage(
 ### How it Works
 
 Chunks are buffered and staged as Azure blocks via `stage_block()`. On `complete_upload()`, all blocks are committed via `commit_block_list()` to form the final blob. For small files, a direct `upload_blob()` is used. Concatenation reuses the block-list mechanism — partials are committed by referencing their staged blocks in the final blob's block list.
+
+`update_offset_atomic()` writes the offset back under `MatchConditions.IfNotModified` on the info blob's ETag, so a concurrent writer on another node loses and gets `False` instead of silently overwriting the winner.
 
 ```python
 storage.complete_upload(upload_id)

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -56,7 +56,7 @@ Compliance status against the [TUS resumable upload protocol v1.0.0](https://tus
 | HEAD on a partial echoes `Upload-Concat: partial` | ✅ | Lets a conformant client distinguish a partial from a normal upload |
 | `Upload-Concat: final;…` merges partials into a final upload | ✅ | Returns `400` if any partial is missing or incomplete |
 | HEAD on a final echoes `Upload-Concat: final;…` | ✅ | Source partial IDs are persisted on the final upload (`concat_partial_ids`); HEAD reconstructs `final;<relative urls>` in original order. Supported by SQLite, S3, GCS, and Azure backends. |
-| Concurrent PATCH/DELETE serialized via `LockBackend` | ✅ | Optional; `423 Locked` on contention beyond `lock_wait_seconds` |
+| Concurrent PATCH/DELETE serialized via `LockBackend` | ✅ | On by default for `TusServer` (in-process `InMemoryLockBackend`; pass `lock_backend=None` to opt out, a distributed backend for multi-node). `TusServerCore` stays lock-free. `423 Locked` on contention beyond `lock_wait_seconds` |
 | Malformed `Content-Length` header → `400` | ✅ | |
 | Negative `Content-Length` → `400` | ✅ | |
 | `Upload-Metadata` larger than 4 KB → `400` | ✅ | DoS protection |
@@ -82,7 +82,7 @@ Compliance status against the [TUS resumable upload protocol v1.0.0](https://tus
 | `Upload-Checksum` (configurable algorithm) | ✅ | `sha1` default; `sha256`, `sha512`, `md5` opt-in |
 | Cross-session URL persistence (fingerprint-based) | ✅ | `FileURLStorage` / `SQLiteURLStorage` / `InMemoryURLStorage` |
 | Full-file fingerprint (not just first 64 KB) | ✅ | SHA-256 of entire content (default; `PartialMD5Fingerprint` and `CallableFingerprint` available) |
-| `409` on concurrent offset conflict (atomic CAS) | ✅ | `UPDATE ... WHERE offset = ?`; returns `409` if row not updated |
+| `409` on concurrent offset conflict (atomic CAS) | ✅ | Every backend does a real compare-and-swap: SQLite `UPDATE ... WHERE offset = ?`, S3/Azure conditional write on the info object's ETag, GCS `if_generation_match`. Returns `409` when the CAS loses. |
 | `409` received → HEAD re-sync before retry | ✅ | Client fetches current offset and re-seeks before retrying chunk |
 | Parallel concatenation upload | ✅ | `parallel_uploads=N` on `upload_file()` |
 | Manual partial / final concatenation primitives | ✅ | `create_partial_upload()` / `create_final_upload()` |

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -54,7 +54,7 @@ Compliance status against the [TUS resumable upload protocol v1.0.0](https://tus
 | DELETE returns `404` for unknown upload | ✅ | |
 | `Upload-Concat: partial` creates a partial upload | ✅ | Partials never fire `on_upload_complete` individually |
 | HEAD on a partial echoes `Upload-Concat: partial` | ✅ | Lets a conformant client distinguish a partial from a normal upload |
-| `Upload-Concat: final;…` merges partials into a final upload | ✅ | Returns `400` if any partial is missing or incomplete |
+| `Upload-Concat: final;…` merges partials into a final upload | ✅ | Returns `400` if any partial is missing or incomplete, or if `Tus-Max-Size` is configured and a source partial still has a deferred length (the total can't be checked) |
 | HEAD on a final echoes `Upload-Concat: final;…` | ✅ | Source partial IDs are persisted on the final upload (`concat_partial_ids`); HEAD reconstructs `final;<relative urls>` in original order. Supported by SQLite, S3, GCS, and Azure backends. |
 | Concurrent PATCH/DELETE serialized via `LockBackend` | ✅ | On by default for `TusServer` (in-process `InMemoryLockBackend`; pass `lock_backend=None` to opt out, a distributed backend for multi-node). `TusServerCore` stays lock-free. `423 Locked` on contention beyond `lock_wait_seconds` |
 | Malformed `Content-Length` header → `400` | ✅ | |

--- a/docs/operations/locks.md
+++ b/docs/operations/locks.md
@@ -1,8 +1,12 @@
 # Distributed Locks
 
-Single-process `SQLiteStorage` serializes writes via `threading.Lock` and `fcntl.flock`. For multi-instance deployments — Kubernetes replicas, ALB-fronted servers behind shared cloud storage — you need cross-host coordination so concurrent PATCH/DELETE on the same upload can't interleave. `LockBackend` provides that.
+Concurrent PATCH/DELETE on the same upload must not interleave — two racing PATCHes at the same offset can otherwise write chunk bytes and advance the offset out of order and corrupt the committed data. `LockBackend` serializes those writes per `upload_id`.
+
+`TusServer` defaults to an in-process `InMemoryLockBackend`, so a server embedded in a threaded or async host (FastAPI, threaded WSGI) is safe **within one process** out of the box. Multi-instance deployments — Kubernetes replicas, ALB-fronted servers behind shared cloud storage — need cross-host coordination and **must** pass a distributed `RedisLockBackend`. (`TusServerCore` has no default lock.)
 
 ## Enabling
+
+`TusServer` already installs `InMemoryLockBackend`; pass `lock_backend` only to tune the timeouts, switch to Redis, or opt out:
 
 ```python
 from resumable_upload import SQLiteStorage, TusServer
@@ -10,13 +14,16 @@ from resumable_upload.locks import InMemoryLockBackend
 
 server = TusServer(
     storage=SQLiteStorage(),
-    lock_backend=InMemoryLockBackend(),
+    lock_backend=InMemoryLockBackend(),  # the default; shown for the timeout tuning
     lock_ttl_seconds=60.0,  # auto-release if the holder crashes
     lock_wait_seconds=5.0,  # 423 Locked when contention exceeds this
 )
+
+# Opt out entirely (no serialization — only safe if writes can never race):
+server = TusServer(storage=SQLiteStorage(), lock_backend=None)
 ```
 
-When `lock_backend` is set, every PATCH and DELETE acquires a key keyed by `upload_id` before performing the write. Contention beyond `lock_wait_seconds` returns `423 Locked` — the standard "try again later" signal.
+When a `lock_backend` is set, every PATCH and DELETE acquires a key keyed by `upload_id` before performing the write. Contention beyond `lock_wait_seconds` returns `423 Locked` — the standard "try again later" signal.
 
 ## Backends
 

--- a/resumable_upload/client/aio/client.py
+++ b/resumable_upload/client/aio/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import os
 from collections.abc import Callable
 from typing import IO, Any
@@ -16,6 +17,30 @@ from resumable_upload.client.stats import UploadStats
 from resumable_upload.exceptions import TusCommunicationError
 from resumable_upload.fingerprint import Fingerprint
 from resumable_upload.url_storage import FileURLStorage, URLStorage
+
+
+def _managed(method):
+    """Auto-close the httpx client for a standalone call.
+
+    When the client is used outside ``async with`` (no ``__aenter__``), each
+    public entry point opens the httpx client lazily and must close it, or the
+    connection pool leaks. A depth counter makes nested public calls (e.g.
+    parallel upload -> create_partial_upload) close only at the outermost one.
+    """
+
+    @functools.wraps(method)
+    async def wrapper(self, *args, **kwargs):
+        if self._entered:
+            return await method(self, *args, **kwargs)
+        self._call_depth += 1
+        try:
+            return await method(self, *args, **kwargs)
+        finally:
+            self._call_depth -= 1
+            if self._call_depth == 0:
+                await self.aclose()
+
+    return wrapper
 
 
 class AsyncTusClient:
@@ -103,17 +128,21 @@ class AsyncTusClient:
         self.on_upload_url_available = on_upload_url_available
         self._transport = _transport
         self._client: Any | None = None  # httpx.AsyncClient, built lazily
+        self._entered = False  # True while inside `async with`
+        self._call_depth = 0  # nesting depth for standalone auto-close
 
     # ------------------------------------------------------------------
     # Async context manager
     # ------------------------------------------------------------------
 
     async def __aenter__(self) -> AsyncTusClient:
+        self._entered = True
         await self._ensure_client()
         return self
 
     async def __aexit__(self, *_: Any) -> None:
         await self.aclose()
+        self._entered = False
 
     async def aclose(self) -> None:
         """Close the underlying httpx AsyncClient."""
@@ -204,6 +233,7 @@ class AsyncTusClient:
     # Public API
     # ------------------------------------------------------------------
 
+    @_managed
     async def upload_file(
         self,
         file_path: str | None = None,
@@ -408,6 +438,7 @@ class AsyncTusClient:
 
         return await self.create_final_upload(list(partial_urls), metadata=metadata)
 
+    @_managed
     async def resume_upload(
         self,
         file_path: str | None = None,
@@ -462,6 +493,7 @@ class AsyncTusClient:
 
         return upload_url
 
+    @_managed
     async def delete_upload(self, upload_url: str) -> None:
         """Delete an upload from the server. A 404 response is silently tolerated.
 
@@ -490,6 +522,7 @@ class AsyncTusClient:
                 f"Failed to delete upload: server returned {resp.status_code}"
             )
 
+    @_managed
     async def create_deferred_upload(
         self,
         metadata: dict[str, str] | None = None,
@@ -501,6 +534,7 @@ class AsyncTusClient:
         """
         return await self._create_upload(file_size=0, metadata=metadata or {}, defer_length=True)
 
+    @_managed
     async def create_partial_upload(
         self,
         file_path: str | None = None,
@@ -562,6 +596,7 @@ class AsyncTusClient:
         finally:
             await up.aclose()
 
+    @_managed
     async def create_final_upload(
         self,
         partial_urls: list[str],
@@ -678,6 +713,7 @@ class AsyncTusClient:
             add_request_id=self.add_request_id,
         )
 
+    @_managed
     async def get_metadata(self, upload_url: str) -> dict[str, str]:
         """Get metadata for an upload via HEAD request.
 
@@ -706,6 +742,7 @@ class AsyncTusClient:
             resp.headers.get("Upload-Metadata"), self.metadata_encoding
         )
 
+    @_managed
     async def get_server_info(self) -> dict[str, Any]:
         """Get server information and capabilities via OPTIONS request.
 
@@ -731,6 +768,7 @@ class AsyncTusClient:
             self.TUS_VERSION,
         )
 
+    @_managed
     async def get_upload_info(self, upload_url: str) -> dict[str, Any]:
         """Get upload status: offset, length, complete flag, and metadata.
 

--- a/resumable_upload/client/aio/uploader.py
+++ b/resumable_upload/client/aio/uploader.py
@@ -374,6 +374,12 @@ class AsyncUploader:
             if progress_callback:
                 progress_callback(self.stats)
 
+        # A deferred-length upload of an empty file runs zero loop iterations,
+        # so Upload-Length is never committed and the upload stays incomplete
+        # forever. Send one final empty PATCH to commit the length.
+        if self._length_deferred and self.offset >= self.file_size:
+            await self._upload_chunk(b"")
+
         return self.url
 
     async def aclose(self) -> None:

--- a/resumable_upload/client/uploader.py
+++ b/resumable_upload/client/uploader.py
@@ -393,6 +393,12 @@ class Uploader:
             if progress_callback:
                 progress_callback(self.stats)
 
+        # A deferred-length upload of an empty file runs zero loop iterations,
+        # so Upload-Length is never committed and the upload stays incomplete
+        # forever. Send one final empty PATCH to commit the length.
+        if self._length_deferred and self.offset >= self.file_size:
+            self._upload_chunk(b"")
+
         return self.url
 
     @property

--- a/resumable_upload/server/handlers/create.py
+++ b/resumable_upload/server/handlers/create.py
@@ -417,7 +417,7 @@ async def handle_create_async(
         # Partials never fire on_upload_complete individually (parity with
         # the PATCH completion path); only the assembled final does.
         if server._on_upload_complete and not plan.is_partial:
-            file_info = server.storage.get_file_info(plan.upload_id)
+            file_info = await server.storage.get_file_info_async(plan.upload_id)
             completion_result = server._invoke_post_hook(
                 server._on_upload_complete,
                 plan.upload_id,
@@ -442,6 +442,11 @@ async def handle_create_final_async(
         declared = 0
         for pid in plan.partial_ids:
             p = await server.storage.get_upload_async(pid)
+            if p and p.get("upload_length") is None:
+                return server._error_response(
+                    400,
+                    "Cannot enforce Tus-Max-Size on a final over deferred-length partials",
+                )
             if p and p.get("upload_length") is not None:
                 declared += p["upload_length"]
         if declared > server.max_size:
@@ -478,7 +483,7 @@ async def handle_create_final_async(
     if server._metrics is not None:
         server._metrics.inc("tusd_uploads_finished_total")
     if server._on_upload_complete:
-        file_info = server.storage.get_file_info(plan.final_id)
+        file_info = await server.storage.get_file_info_async(plan.final_id)
         server._invoke_post_hook(
             server._on_upload_complete, plan.final_id, plan.metadata, file_info
         )

--- a/resumable_upload/server/handlers/patch.py
+++ b/resumable_upload/server/handlers/patch.py
@@ -409,7 +409,7 @@ async def handle_patch_async(
         if server._metrics is not None:
             server._metrics.inc("tusd_uploads_finished_total")
         if server._on_upload_complete and not upload.get("is_partial"):
-            file_info = server.storage.get_file_info(upload_id)
+            file_info = await server.storage.get_file_info_async(upload_id)
             completion_result = server._invoke_post_hook(
                 server._on_upload_complete,
                 upload_id,

--- a/resumable_upload/server/http_handler.py
+++ b/resumable_upload/server/http_handler.py
@@ -74,6 +74,12 @@ class TusHTTPRequestHandler(BaseHTTPRequestHandler):
         assert self.tus_server is not None
         self.send_response(status)
         self.send_header("Tus-Resumable", self.tus_server.TUS_VERSION)
+        # Transport-level rejections short-circuit before the core, so add CORS
+        # here too — otherwise a browser can't read the status of a 400/413 that
+        # the chunked-body parser or size gate produced (cross-origin opaque).
+        origin = self.headers.get("Origin")
+        for key, value in self.tus_server._add_cors_headers({}, origin=origin).items():
+            self.send_header(key, value)
         self.end_headers()
         self.wfile.write(message)
 

--- a/resumable_upload/server/server.py
+++ b/resumable_upload/server/server.py
@@ -5,14 +5,33 @@ to instantiate. It exists as a distinct subclass so future extensions can
 land here without forcing every downstream user to update imports.
 """
 
+from typing import Any
+
+from resumable_upload.locks import InMemoryLockBackend
 from resumable_upload.server.core import TusServerCore
+
+_UNSET: Any = object()
 
 
 class TusServer(TusServerCore):
     """TUS server with all standard extensions enabled.
 
-    Behaviorally identical to :class:`TusServerCore` today. Reserve
-    ``TusServerCore`` for downstream code that wants to subclass against the
-    minimal surface; reserve ``TusServer`` for users who want the canonical
-    server with whatever extensions ship by default in future releases.
+    Differs from :class:`TusServerCore` in one way: it defaults ``lock_backend``
+    to an :class:`InMemoryLockBackend` so that a server embedded in a threaded
+    or async host (FastAPI, threaded WSGI) serializes concurrent PATCH/DELETE
+    on the same upload out of the box — without a lock, two racing PATCHes at
+    the same offset can interleave the chunk write and the offset CAS and
+    corrupt committed bytes.
+
+    The in-memory lock only covers a single process. **Multi-process or
+    multi-node deployments must pass an explicit distributed lock**
+    (``RedisLockBackend``); pass ``lock_backend=None`` to opt out entirely.
+
+    Reserve ``TusServerCore`` for downstream code that wants the minimal,
+    lock-free surface.
     """
+
+    def __init__(self, *args: Any, lock_backend: Any = _UNSET, **kwargs: Any) -> None:
+        if lock_backend is _UNSET:
+            lock_backend = InMemoryLockBackend()
+        super().__init__(*args, lock_backend=lock_backend, **kwargs)

--- a/resumable_upload/storage/azure_storage.py
+++ b/resumable_upload/storage/azure_storage.py
@@ -18,7 +18,8 @@ from resumable_upload.storage.base import Storage
 logger = logging.getLogger(__name__)
 
 try:
-    from azure.core.exceptions import ResourceNotFoundError
+    from azure.core import MatchConditions
+    from azure.core.exceptions import ResourceModifiedError, ResourceNotFoundError
     from azure.storage.blob import BlobBlock, BlobServiceClient
 except ImportError as e:
     raise ImportError(
@@ -199,11 +200,32 @@ class AzureBlobStorage(Storage):
         self._write_info(upload_id, info)
 
     def update_offset_atomic(self, upload_id: str, expected_offset: int, new_offset: int) -> bool:
-        info = self._read_info(upload_id)
-        if info is None or info["offset"] != expected_offset:
+        # Conditional compare-and-swap via the info blob's ETag: write back only
+        # if it hasn't changed (If-Match). A concurrent writer that already
+        # advanced the offset changes the ETag, so the loser's conditional
+        # upload raises ResourceModifiedError and returns False (invariant #6).
+        from azure.storage.blob import ContentSettings
+
+        blob = self._get_blob_client(self._info_key(upload_id))
+        try:
+            downloader = blob.download_blob()
+            etag = downloader.properties.etag
+            info = json.loads(downloader.readall())
+        except ResourceNotFoundError:
+            return False
+        if info["offset"] != expected_offset:
             return False
         info["offset"] = new_offset
-        self._write_info(upload_id, info)
+        try:
+            blob.upload_blob(
+                json.dumps(info).encode(),
+                overwrite=True,
+                content_settings=ContentSettings(content_type="application/json"),
+                etag=etag,
+                match_condition=MatchConditions.IfNotModified,
+            )
+        except ResourceModifiedError:
+            return False
         return True
 
     def delete_upload(self, upload_id: str) -> None:

--- a/resumable_upload/storage/base.py
+++ b/resumable_upload/storage/base.py
@@ -69,8 +69,9 @@ class Storage(ABC):
         """Update offset only if current value equals expected_offset.
 
         Returns True on success, False if offset already changed (concurrent conflict).
-        Default implementation is non-atomic; SQLiteStorage overrides with a
-        single conditional UPDATE for true atomicity.
+        The default implementation above is non-atomic; every shipped backend
+        overrides it with a real compare-and-swap — SQLite with a conditional
+        UPDATE, S3 and Azure with an If-Match ETag, GCS with if_generation_match.
         """
         upload = self.get_upload(upload_id)
         if upload is None or upload["offset"] != expected_offset:

--- a/resumable_upload/storage/gcs_storage.py
+++ b/resumable_upload/storage/gcs_storage.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 try:
     from google.cloud import storage as gcs_lib
-    from google.cloud.exceptions import NotFound
+    from google.cloud.exceptions import NotFound, PreconditionFailed
 except ImportError as e:
     raise ImportError(
         "google-cloud-storage is required for GCSStorage. "
@@ -167,11 +167,25 @@ class GCSStorage(Storage):
         self._write_info(upload_id, info)
 
     def update_offset_atomic(self, upload_id: str, expected_offset: int, new_offset: int) -> bool:
-        info = self._read_info(upload_id)
-        if info is None or info["offset"] != expected_offset:
+        # Conditional compare-and-swap via GCS object generation: write back
+        # only if the object hasn't changed since we read it. A concurrent
+        # writer that already advanced the offset bumps the generation, so the
+        # losing if_generation_match write gets 412 and returns False.
+        blob = self.gcs_bucket.get_blob(self._info_key(upload_id))
+        if blob is None:
+            return False
+        info = json.loads(blob.download_as_bytes())
+        if info["offset"] != expected_offset:
             return False
         info["offset"] = new_offset
-        self._write_info(upload_id, info)
+        try:
+            blob.upload_from_string(
+                json.dumps(info).encode(),
+                content_type="application/json",
+                if_generation_match=blob.generation,
+            )
+        except PreconditionFailed:
+            return False
         return True
 
     def delete_upload(self, upload_id: str) -> None:

--- a/resumable_upload/storage/s3_storage.py
+++ b/resumable_upload/storage/s3_storage.py
@@ -169,11 +169,32 @@ class S3Storage(Storage):
         self._write_info(upload_id, info)
 
     def update_offset_atomic(self, upload_id: str, expected_offset: int, new_offset: int) -> bool:
-        info = self._read_info(upload_id)
-        if info is None or info["offset"] != expected_offset:
+        # Conditional compare-and-swap: read the info object's ETag, then write
+        # back only if it hasn't changed (S3 If-Match). Two concurrent writers
+        # that both read offset==expected can't both win — the second's
+        # conditional PUT gets 412 and returns False (TUS invariant #6).
+        try:
+            resp = self.s3.get_object(Bucket=self.bucket, Key=self._info_key(upload_id))
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchKey":
+                return False
+            raise
+        info = json.loads(resp["Body"].read())
+        if info["offset"] != expected_offset:
             return False
         info["offset"] = new_offset
-        self._write_info(upload_id, info)
+        try:
+            self.s3.put_object(
+                Bucket=self.bucket,
+                Key=self._info_key(upload_id),
+                Body=json.dumps(info).encode(),
+                ContentType="application/json",
+                IfMatch=resp["ETag"],
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] in ("PreconditionFailed", "412"):
+                return False
+            raise
         return True
 
     def delete_upload(self, upload_id: str) -> None:

--- a/resumable_upload/storage/sqlite_storage.py
+++ b/resumable_upload/storage/sqlite_storage.py
@@ -209,23 +209,27 @@ class SQLiteStorage(Storage):
             conn.close()
 
     def complete_upload(self, upload_id: str) -> bool:
-        """Mark upload as completed, clean up lock, and return True.
+        """Mark upload as completed, clean up lock, and report first completion.
 
-        Sets completed=1 in the DB (idempotent) and removes the per-upload
-        lock entry. Always returns True for local storage.
+        Uses a conditional ``UPDATE ... WHERE completed = 0`` so only the call
+        that actually transitions the row returns True (the base contract). If
+        two callers assemble the same final (the crash-reclaim clause in
+        :meth:`try_assemble_final` can let that happen across processes), only
+        the first fires ``on_upload_complete`` — the second gets False.
         """
         conn = sqlite3.connect(self.db_path, timeout=self.timeout)
         try:
-            conn.execute(
-                "UPDATE uploads SET completed = 1 WHERE upload_id = ?",
+            cursor = conn.execute(
+                "UPDATE uploads SET completed = 1 WHERE upload_id = ? AND completed = 0",
                 (upload_id,),
             )
             conn.commit()
+            first_completion = cursor.rowcount == 1
         finally:
             conn.close()
         with self._file_locks_lock:
             self._file_locks.pop(upload_id, None)
-        return True
+        return first_completion
 
     def delete_upload(self, upload_id: str) -> None:
         """Delete an upload entry."""

--- a/tests/test_defer_length.py
+++ b/tests/test_defer_length.py
@@ -299,3 +299,113 @@ class TestClientEndToEnd:
         assert info["complete"] is True
         assert info["length"] == len(data)
         assert urllib.request.urlopen(url).read() == data
+
+    def test_deferred_empty_file_completes(self, live, tmp_path):
+        # C1: a deferred-length upload of a 0-byte file sends no PATCH, so the
+        # length was never committed and the upload hung incomplete forever.
+        # A final empty PATCH must commit Upload-Length: 0 and complete it.
+        import urllib.request
+
+        from resumable_upload.client import TusClient
+
+        base_url, _ = live
+        path = tmp_path / "empty.bin"
+        path.write_bytes(b"")
+        client = TusClient(base_url, chunk_size=1024)
+        url = client.create_deferred_upload(metadata={"filename": "empty.bin"})
+        client.resume_upload(str(path), url)
+        info = client.get_upload_info(url)
+        assert info["complete"] is True
+        assert info["length"] == 0
+        assert urllib.request.urlopen(url).read() == b""
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class TestAsyncClientEndToEnd:
+    """The async client over real HTTP: deferred-length + 0-byte completion."""
+
+    @pytest.fixture
+    def live(self):
+        import threading
+        from http.server import HTTPServer
+
+        from resumable_upload.server import TusHTTPRequestHandler
+
+        temp_dir = tempfile.mkdtemp()
+        storage = SQLiteStorage(
+            db_path=os.path.join(temp_dir, "u.db"),
+            upload_dir=os.path.join(temp_dir, "files"),
+        )
+        tus = TusServer(storage=storage, base_path="/files", enable_downloads=True)
+
+        class Handler(TusHTTPRequestHandler):
+            pass
+
+        Handler.tus_server = tus
+        httpd = HTTPServer(("127.0.0.1", 0), Handler)
+        port = httpd.server_address[1]
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        try:
+            yield f"http://127.0.0.1:{port}/files", storage
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @pytest.mark.anyio
+    async def test_deferred_empty_file_completes(self, live, tmp_path, anyio_backend):
+        # C1 async parity: deferred-length + 0-byte must commit and complete.
+        pytest.importorskip("httpx")
+        import urllib.request
+
+        from resumable_upload import AsyncTusClient
+
+        base_url, _ = live
+        path = tmp_path / "empty.bin"
+        path.write_bytes(b"")
+        async with AsyncTusClient(base_url, chunk_size=1024) as client:
+            url = await client.create_deferred_upload(metadata={"filename": "empty.bin"})
+            await client.resume_upload(str(path), url)
+            info = await client.get_upload_info(url)
+        assert info["complete"] is True
+        assert info["length"] == 0
+        assert urllib.request.urlopen(url).read() == b""
+
+    @pytest.mark.anyio
+    async def test_standalone_call_closes_client(self, live, tmp_path, anyio_backend):
+        # C4: used without `async with`, each public call must close its httpx
+        # client (else the connection pool leaks).
+        pytest.importorskip("httpx")
+        from resumable_upload import AsyncTusClient
+
+        base_url, _ = live
+        path = tmp_path / "f.bin"
+        path.write_bytes(b"hi")
+        client = AsyncTusClient(base_url, chunk_size=1024)
+        url = await client.upload_file(str(path))  # no context manager
+        assert client._client is None  # closed after the standalone call
+        info = await client.get_upload_info(url)  # opens + closes again
+        assert info["complete"] is True
+        assert client._client is None
+
+    @pytest.mark.anyio
+    async def test_standalone_parallel_upload_nesting_safe(self, live, tmp_path, anyio_backend):
+        # C4: nested public calls (parallel upload -> create_partial/final) must
+        # NOT close the client mid-flight — only the outermost call closes.
+        import os
+
+        pytest.importorskip("httpx")
+        from resumable_upload import AsyncTusClient
+
+        base_url, _ = live
+        data = os.urandom(9000)
+        path = tmp_path / "big.bin"
+        path.write_bytes(data)
+        client = AsyncTusClient(base_url, chunk_size=1024)
+        url = await client.upload_file(str(path), parallel_uploads=3)
+        assert client._client is None
+        assert (await client.get_upload_info(url))["complete"] is True

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -85,6 +85,39 @@ class TestLockBackendContract:
         assert lock.acquire("k-b", ttl_seconds=5) is not None
 
 
+class TestDefaultLockBackend:
+    """S2: TusServer defaults to an in-process lock; TusServerCore does not."""
+
+    def _storage(self, tmp_path):
+        import os
+
+        from resumable_upload.storage import SQLiteStorage
+
+        return SQLiteStorage(
+            db_path=os.path.join(str(tmp_path), "u.db"),
+            upload_dir=os.path.join(str(tmp_path), "files"),
+        )
+
+    def test_tusserver_defaults_to_in_memory_lock(self, tmp_path):
+        from resumable_upload.server import TusServer
+
+        server = TusServer(storage=self._storage(tmp_path), base_path="/files")
+        assert isinstance(server._locks, InMemoryLockBackend)
+
+    def test_tusserver_explicit_none_opts_out(self, tmp_path):
+        # CLI `--lock-backend none` passes None explicitly; must stay unlocked.
+        from resumable_upload.server import TusServer
+
+        server = TusServer(storage=self._storage(tmp_path), base_path="/files", lock_backend=None)
+        assert server._locks is None
+
+    def test_core_has_no_default_lock(self, tmp_path):
+        from resumable_upload.server import TusServerCore
+
+        server = TusServerCore(storage=self._storage(tmp_path), base_path="/files")
+        assert server._locks is None
+
+
 class TestServerLockIntegration:
     """Server uses LockBackend to serialize PATCH/DELETE on the same upload."""
 

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -218,6 +218,76 @@ class TestAssemblyRobustness:
         )
         assert status == 201
 
+    @pytest.mark.anyio
+    async def test_final_over_deferred_partials_rejected_async(self, storage, anyio_backend):
+        # Async parity: handle_create_final_async must reject the same request
+        # the sync path does (previously it silently accepted a pending final).
+        server = TusServer(storage=storage, base_path="/files", max_size=8)
+        locs = []
+        for _ in range(2):
+            _, h, _ = await server.handle_request_async(
+                "POST",
+                "/files",
+                _h(**{"Upload-Defer-Length": "1", "Upload-Concat": "partial"}),
+                b"",
+            )
+            locs.append(h["Location"])
+
+        status, _, body = await server.handle_request_async(
+            "POST", "/files", _h(**{"Upload-Concat": "final;" + " ".join(locs)}), b""
+        )
+        assert status == 400
+        assert b"deferred-length" in body
+
+    def test_transport_level_error_carries_cors(self, storage):
+        # A chunked PATCH whose declared chunk exceeds max_chunk_size is
+        # rejected by the transport parser (_send_error), short-circuiting the
+        # core. That 413 must still carry CORS so a browser can read the status.
+        server = TusServer(
+            storage=storage,
+            base_path="/files",
+            cors_allow_origins="*",
+            max_chunk_size=10,
+        )
+
+        class Handler(TusHTTPRequestHandler):
+            pass
+
+        Handler.tus_server = server
+        httpd = HTTPServer(("127.0.0.1", 0), Handler)
+        port = httpd.server_address[1]
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        try:
+            conn = socket.create_connection(("127.0.0.1", port), timeout=5)
+            req = (
+                "PATCH /files/00000000-0000-0000-0000-000000000000 HTTP/1.1\r\n"
+                f"Host: 127.0.0.1:{port}\r\n"
+                "Tus-Resumable: 1.0.0\r\n"
+                "Upload-Offset: 0\r\n"
+                "Content-Type: application/offset+octet-stream\r\n"
+                "Origin: https://app.example\r\n"
+                "Transfer-Encoding: chunked\r\n"
+                "\r\n"
+                "14\r\n"  # 0x14 = 20 bytes, over the 10-byte max_chunk_size
+                "xxxxxxxxxxxxxxxxxxxx\r\n"
+                "0\r\n\r\n"
+            )
+            conn.sendall(req.encode())
+            raw = b""
+            while b"\r\n\r\n" not in raw:
+                part = conn.recv(4096)
+                if not part:
+                    break
+                raw += part
+            conn.close()
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+        resp = raw.decode("latin1")
+        assert "413" in resp.split("\r\n", 1)[0]
+        assert "Access-Control-Allow-Origin: *" in resp
+
     def test_pending_final_row_is_atomic(self, storage):
         # Finding 8: the row must carry concat_partial_ids from birth — a
         # crash between INSERT and UPDATE previously left a plain orphan row.

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -111,6 +111,15 @@ class TestSQLiteStorage:
         assert sum(results) == 1, f"expected exactly one winner, got {results}"
         assert storage.get_upload("cas-race")["offset"] == 256
 
+    def test_complete_upload_returns_true_only_on_first_completion(self, storage):
+        # C3: the crash-reclaim clause in try_assemble_final can let two callers
+        # assemble the same final; complete_upload must transition once so the
+        # on_upload_complete hook (gated on this return) fires exactly once.
+        storage.create_upload("done", 5, {})
+        assert storage.complete_upload("done") is True  # 0 -> 1
+        assert storage.complete_upload("done") is False  # already completed
+        assert storage.get_upload("done")["completed"] is True
+
     def test_write_and_read_chunk(self, storage):
         """Test writing and reading chunks."""
         upload_id = "test-upload-3"

--- a/tests/test_storage_async_native.py
+++ b/tests/test_storage_async_native.py
@@ -45,7 +45,10 @@ def _h(**extra: str) -> dict[str, str]:
 
 @pytest.fixture
 def server() -> TusServer:
-    return TusServer(storage=AsyncDictStorage(), base_path="/files")
+    # lock_backend=None: this test asserts the STORAGE async path is native
+    # (no to_thread). The default InMemoryLockBackend legitimately wraps its
+    # sync acquire/release in to_thread, which is unrelated to storage I/O.
+    return TusServer(storage=AsyncDictStorage(), base_path="/files", lock_backend=None)
 
 
 @pytest.mark.anyio

--- a/tests/test_storage_azure.py
+++ b/tests/test_storage_azure.py
@@ -13,10 +13,20 @@ class FakeBlobClient:
         self.blob_name = name
         self._staged_blocks: dict[str, bytes] = {}
 
-    def upload_blob(self, data, overwrite=False, content_settings=None):
+    def upload_blob(
+        self, data, overwrite=False, content_settings=None, etag=None, match_condition=None
+    ):
         if isinstance(data, str):
             data = data.encode()
+        # Enforce the If-Match condition so the CAS conflict path is testable.
+        if match_condition is not None and etag is not None:
+            current = self._container._etags.get(self.blob_name)
+            if current is not None and etag != current:
+                from azure.core.exceptions import ResourceModifiedError
+
+                raise ResourceModifiedError("etag mismatch")
         self._container._blobs[self.blob_name] = data
+        self._container._bump_etag(self.blob_name)
         # Clear staged blocks on direct upload
         self._staged_blocks.clear()
 
@@ -26,15 +36,21 @@ class FakeBlobClient:
         if self.blob_name not in self._container._blobs:
             raise ResourceNotFoundError(f"Blob {self.blob_name} not found")
         data = self._container._blobs[self.blob_name]
+        etag = self._container._etags.get(self.blob_name)
+
+        class _Props:
+            def __init__(self, etag):
+                self.etag = etag
 
         class FakeDownload:
-            def __init__(self, content):
+            def __init__(self, content, etag):
                 self._content = content
+                self.properties = _Props(etag)
 
             def readall(self):
                 return self._content
 
-        return FakeDownload(data)
+        return FakeDownload(data, etag)
 
     def delete_blob(self):
         from azure.core.exceptions import ResourceNotFoundError
@@ -76,6 +92,12 @@ class FakeContainerClient:
         self._blobs: dict[str, bytes] = {}
         self._staged: dict[str, dict[str, bytes]] = {}
         self._blob_clients: dict[str, FakeBlobClient] = {}
+        self._etags: dict[str, str] = {}
+        self._etag_counter = 0
+
+    def _bump_etag(self, name: str) -> None:
+        self._etag_counter += 1
+        self._etags[name] = f'"etag-{self._etag_counter}"'
 
     def get_blob_client(self, blob_name: str) -> FakeBlobClient:
         if blob_name not in self._blob_clients:
@@ -100,6 +122,12 @@ def mock_azure_imports():
     class ResourceNotFoundError(Exception):
         pass
 
+    class ResourceModifiedError(Exception):
+        pass
+
+    class MatchConditions:
+        IfNotModified = "IfNotModified"
+
     class BlobBlock:
         def __init__(self, block_id):
             self.block_id = block_id
@@ -119,8 +147,10 @@ def mock_azure_imports():
     # Build module hierarchy
     azure_mod = types.ModuleType("azure")
     core_mod = types.ModuleType("azure.core")
+    core_mod.MatchConditions = MatchConditions
     core_exc_mod = types.ModuleType("azure.core.exceptions")
     core_exc_mod.ResourceNotFoundError = ResourceNotFoundError
+    core_exc_mod.ResourceModifiedError = ResourceModifiedError
     storage_mod = types.ModuleType("azure.storage")
     blob_mod = types.ModuleType("azure.storage.blob")
     blob_mod.BlobServiceClient = BlobServiceClient
@@ -310,6 +340,32 @@ class TestAzureStorageOffset:
         assert storage.update_offset_atomic("conflict-id", 0, 50) is False
         upload = storage.get_upload("conflict-id")
         assert upload["offset"] == 30
+
+    def test_update_offset_atomic_loses_to_concurrent_writer(self, storage):
+        """A CAS that reads, then loses the race, must not clobber the winner.
+
+        Both writers see offset 0. The loser's write-back has to fail its
+        If-Match condition on the ETag the winner already changed — a plain
+        read-modify-write would silently overwrite it (TUS invariant #6).
+        """
+        storage.create_upload("cas-race", 100, {})
+        real_download = FakeBlobClient.download_blob
+        raced = []
+
+        def download_then_let_rival_win(blob_self):
+            downloader = real_download(blob_self)
+            if not raced:  # only interleave the first read
+                raced.append(True)
+                storage.update_offset("cas-race", 40)  # another node commits first
+            return downloader
+
+        FakeBlobClient.download_blob = download_then_let_rival_win
+        try:
+            assert storage.update_offset_atomic("cas-race", 0, 50) is False
+        finally:
+            FakeBlobClient.download_blob = real_download
+        assert raced, "the rival write never interleaved; the test proved nothing"
+        assert storage.get_upload("cas-race")["offset"] == 40
 
 
 # -- File info ---------------------------------------------------------------

--- a/tests/test_storage_gcs.py
+++ b/tests/test_storage_gcs.py
@@ -8,14 +8,24 @@ import pytest
 class FakeBlob:
     """In-memory blob that mimics google.cloud.storage.Blob."""
 
-    def __init__(self, name: str, bucket: "FakeBucket"):
+    def __init__(self, name: str, bucket: "FakeBucket", generation=None):
         self.name = name
         self._bucket = bucket
+        self.generation = generation
 
-    def upload_from_string(self, data, content_type=None):
+    def upload_from_string(self, data, content_type=None, if_generation_match=None):
         if isinstance(data, str):
             data = data.encode()
+        # Enforce the generation precondition so the CAS conflict path is testable.
+        if if_generation_match is not None:
+            current = self._bucket._generations.get(self.name)
+            if current != if_generation_match:
+                from google.cloud.exceptions import PreconditionFailed
+
+                raise PreconditionFailed("generation mismatch")
         self._bucket._blobs[self.name] = data
+        self._bucket._generations[self.name] = self._bucket._generations.get(self.name, 0) + 1
+        self.generation = self._bucket._generations[self.name]
 
     def download_as_bytes(self):
         from google.cloud.exceptions import NotFound
@@ -44,9 +54,17 @@ class FakeBucket:
     def __init__(self, name: str):
         self.name = name
         self._blobs: dict[str, bytes] = {}
+        self._generations: dict[str, int] = {}
 
     def blob(self, name: str) -> FakeBlob:
         return FakeBlob(name, self)
+
+    def get_blob(self, name: str):
+        # Real GCS get_blob() returns None if the object doesn't exist, else a
+        # blob populated with its current generation.
+        if name not in self._blobs:
+            return None
+        return FakeBlob(name, self, generation=self._generations.get(name))
 
     def copy_blob(self, source_blob, destination_bucket, destination_key):
         destination_bucket._blobs[destination_key] = self._blobs[source_blob.name]
@@ -83,8 +101,12 @@ def mock_gcs_imports():
     class NotFound(Exception):
         pass
 
+    class PreconditionFailed(Exception):
+        pass
+
     exceptions_mod = types.ModuleType("google.cloud.exceptions")
     exceptions_mod.NotFound = NotFound
+    exceptions_mod.PreconditionFailed = PreconditionFailed
 
     # Create mock google.cloud.storage module
     storage_mod = types.ModuleType("google.cloud.storage")
@@ -270,6 +292,32 @@ class TestGCSStorageOffset:
         assert storage.update_offset_atomic("conflict-id", 0, 50) is False
         upload = storage.get_upload("conflict-id")
         assert upload["offset"] == 30
+
+    def test_update_offset_atomic_loses_to_concurrent_writer(self, storage):
+        """A CAS that reads, then loses the race, must not clobber the winner.
+
+        Both writers see offset 0. The loser's write-back has to fail its
+        if_generation_match precondition — a plain read-modify-write would
+        silently overwrite the winner's committed offset (TUS invariant #6).
+        """
+        storage.create_upload("cas-race", 100, {})
+        real_download = FakeBlob.download_as_bytes
+        raced = []
+
+        def download_then_let_rival_win(blob_self):
+            data = real_download(blob_self)
+            if not raced:  # only interleave the first read
+                raced.append(True)
+                storage.update_offset("cas-race", 40)  # another node commits first
+            return data
+
+        FakeBlob.download_as_bytes = download_then_let_rival_win
+        try:
+            assert storage.update_offset_atomic("cas-race", 0, 50) is False
+        finally:
+            FakeBlob.download_as_bytes = real_download
+        assert raced, "the rival write never interleaved; the test proved nothing"
+        assert storage.get_upload("cas-race")["offset"] == 40
 
 
 # -- File info ---------------------------------------------------------------

--- a/tests/test_storage_s3.py
+++ b/tests/test_storage_s3.py
@@ -176,6 +176,32 @@ class TestS3StorageOffset:
         upload = storage.get_upload("conflict-id")
         assert upload["offset"] == 30
 
+    def test_update_offset_atomic_loses_to_concurrent_writer(self, storage):
+        """A CAS that reads, then loses the race, must not clobber the winner.
+
+        Both writers see offset 0. The loser's write-back has to fail on the
+        ETag the winner already changed — a plain read-modify-write would
+        silently overwrite the winner's committed offset (TUS invariant #6).
+        """
+        storage.create_upload("cas-race", 100, {})
+        real_get_object = storage.s3.get_object
+        raced = []
+
+        def get_object_then_let_rival_win(**kwargs):
+            resp = real_get_object(**kwargs)
+            if not raced:  # only interleave the first read
+                raced.append(True)
+                storage.update_offset("cas-race", 40)  # another node commits first
+            return resp
+
+        storage.s3.get_object = get_object_then_let_rival_win
+        try:
+            assert storage.update_offset_atomic("cas-race", 0, 50) is False
+        finally:
+            storage.s3.get_object = real_get_object
+        assert raced, "the rival write never interleaved; the test proved nothing"
+        assert storage.get_upload("cas-race")["offset"] == 40
+
 
 # -- File info ---------------------------------------------------------------
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits — type(scope): imperative summary, ≤72 chars.
Types: feat | fix | chore | docs | refactor | test | build | ci
Example: fix(server): apply Upload-Expires to concatenated final uploads
-->

## Purpose

Makes `update_offset_atomic` a real CAS on S3/Azure (If-Match) and GCS (if_generation_match), gates `on_upload_complete` on a conditional transition, defaults `TusServer` to an in-process lock backend, and fixes async concat parity, blocking IO in async completion, CORS on transport-level rejections, deferred 0-byte uploads, and `AsyncTusClient` used without `async with`.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
