### PR TITLE
ci: run interop lanes against tusd, tus-js, tus-py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -76,6 +79,32 @@ jobs:
     - name: Test S3 storage backend
       run: |
         pytest tests/test_storage_s3.py -v --tb=short
+
+  interop:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev,test]"
+        pip install tuspy
+
+    - name: Provision tus-js-client
+      run: npm install --ignore-scripts --silent
+      working-directory: tests/interop
+
+    - name: Provision tusd
+      run: echo "TUSD_BIN=$(sh tests/interop/fetch_tusd.sh)" >> "$GITHUB_ENV"
+
+    - name: Run interop lanes
+      run: pytest tests/test_interop.py -v -rs
 
   lint-types:
     runs-on: ubuntu-latest

--- a/tests/interop/fetch_tusd.sh
+++ b/tests/interop/fetch_tusd.sh
@@ -2,6 +2,12 @@
 # Download the latest tusd release binary from GitHub into tests/interop/tusd/
 # (gitignored) and print its path. Skips the download if already present;
 # delete tests/interop/tusd/ to force a refresh to the newest release.
+#
+# The lane deliberately tracks the newest tusd rather than a pinned version:
+# the point of the interop suite is to find out when upstream changes break
+# compatibility. The download is checked against the sha256 GitHub publishes
+# alongside the asset, which catches a truncated or corrupted transfer — it is
+# not a supply-chain pin, since both come from the same release.
 set -e
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -23,7 +29,8 @@ case "$ARCH" in
         ;;
 esac
 case "$OS" in
-    linux | darwin) ;;
+    linux) EXT=tar.gz ;;
+    darwin) EXT=zip ;;
     *)
         echo "fetch_tusd: unsupported os: $OS" >&2
         exit 1
@@ -31,13 +38,29 @@ case "$OS" in
 esac
 
 ASSET="tusd_${OS}_${ARCH}"
-URL="https://github.com/tus/tusd/releases/latest/download/${ASSET}.zip"
+URL="https://github.com/tus/tusd/releases/latest/download/${ASSET}.${EXT}"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 echo "fetch_tusd: downloading latest tusd ($ASSET)..." >&2
-curl -fsSL "$URL" -o "$TMP/tusd.zip"
-unzip -q -o "$TMP/tusd.zip" -d "$TMP"
+curl -fsSL "$URL" -o "$TMP/$ASSET.$EXT"
+
+EXPECTED="$(curl -fsSL "$URL.sha256" | cut -d' ' -f1)"
+if command -v sha256sum >/dev/null 2>&1; then
+    ACTUAL="$(sha256sum "$TMP/$ASSET.$EXT" | cut -d' ' -f1)"
+else
+    ACTUAL="$(shasum -a 256 "$TMP/$ASSET.$EXT" | cut -d' ' -f1)"
+fi
+if [ -z "$EXPECTED" ] || [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "fetch_tusd: sha256 mismatch for $ASSET.$EXT: expected ${EXPECTED:-<none published>}, got $ACTUAL" >&2
+    exit 1
+fi
+
+if [ "$EXT" = "zip" ]; then
+    unzip -q -o "$TMP/$ASSET.$EXT" -d "$TMP"
+else
+    tar -xzf "$TMP/$ASSET.$EXT" -C "$TMP"
+fi
 mkdir -p "$DIR/tusd"
 cp "$TMP/$ASSET/tusd" "$BIN"
 chmod +x "$BIN"


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits — type(scope): imperative summary, ≤72 chars.
Types: feat | fix | chore | docs | refactor | test | build | ci
Example: fix(server): apply Upload-Expires to concatenated final uploads
-->

## Purpose

Turns the interop suite into a CI job (provisions tusd + tus-js-client per run) and fixes `fetch_tusd.sh` to handle the Linux tar.gz asset and verify the published sha256.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
