### PR TITLE
ci: fail the interop lane when tusd is not provisioned

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,13 @@ jobs:
       working-directory: tests/interop
 
     - name: Provision tusd
-      run: echo "TUSD_BIN=$(sh tests/interop/fetch_tusd.sh)" >> "$GITHUB_ENV"
+      # Assign first: under `bash -e` a failing command substitution inside
+      # `echo ...` leaves the echo successful, so the lane used to go green
+      # with TUSD_BIN empty and every tusd test skipped.
+      run: |
+        TUSD_BIN="$(sh tests/interop/fetch_tusd.sh)"
+        test -x "$TUSD_BIN" || { echo "::error::tusd provisioning produced no binary"; exit 1; }
+        echo "TUSD_BIN=$TUSD_BIN" >> "$GITHUB_ENV"
 
     - name: Run interop lanes
       run: pytest tests/test_interop.py -v -rs


### PR DESCRIPTION
## Purpose

Under `bash -e` a failing command substitution inside `echo` still leaves the echo successful, so a failed fetch_tusd.sh wrote an empty TUSD_BIN, every tusd test skipped, and the lane reported pass the opposite of what a lane that exists to catch upstream drift should do.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
