### PR TITLE
fix(storage): raise boto3 floor to 1.35.69 for conditional writes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ async = [
     "httpx>=0.24",
 ]
 s3 = [
-    "boto3>=1.26.0",
+    "boto3>=1.35.69",
 ]
 gcs = [
     "google-cloud-storage>=2.0.0",
@@ -80,7 +80,7 @@ redis = [
     "redis>=5.0",
 ]
 all-storage = [
-    "boto3>=1.26.0",
+    "boto3>=1.35.69",
     "google-cloud-storage>=2.0.0",
     "azure-storage-blob>=12.0.0",
 ]

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -33,3 +33,26 @@ def test_all_extra_covers_every_feature_extra():
     referenced = _extra("all")
     missing = [n for n in features if not re.search(rf"[\[,]{n}[,\]]", referenced)]
     assert not missing, f"[all] does not cover: {', '.join(missing)}"
+
+
+# S3 conditional writes (If-Match on PutObject) landed in botocore 1.35.69;
+# boto3 1.35.69 is the first release that pins it. S3Storage.update_offset_atomic
+# passes IfMatch unconditionally, and botocore raises ParamValidationError —
+# not a ClientError, so nothing catches it — when the parameter is unknown.
+# An older floor therefore turns every PATCH against S3Storage into a 500.
+_BOTO3_IF_MATCH_FLOOR = (1, 35, 69)
+
+
+def _boto3_pins():
+    pins = re.findall(r'"boto3>=([0-9.]+)"', _OPTIONAL_DEPS)
+    assert pins, "no boto3 pin found in [project.optional-dependencies]"
+    return pins
+
+
+def test_boto3_floor_supports_conditional_put():
+    for pin in _boto3_pins():
+        parsed = tuple(int(p) for p in pin.split("."))
+        assert parsed >= _BOTO3_IF_MATCH_FLOOR, (
+            f"boto3>={pin} predates If-Match on PutObject "
+            f"(needs >={'.'.join(str(p) for p in _BOTO3_IF_MATCH_FLOOR)})"
+        )


### PR DESCRIPTION
## Purpose

S3Storage.update_offset_atomic passes IfMatch to put_object. That parameter landed in botocore 1.35.69; botocore rejects unknown parameters with ParamValidationError, which is not a ClientError and so escapes the handler around the CAS. Against an older boto3 every PATCH raised, after write_chunk had already staged the bytes.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
