### PR TITLE
fix(server): send CORS headers on Content-Length rejections too

### DIFF
--- a/resumable_upload/server/http_handler.py
+++ b/resumable_upload/server/http_handler.py
@@ -76,7 +76,8 @@ class TusHTTPRequestHandler(BaseHTTPRequestHandler):
         self.send_header("Tus-Resumable", self.tus_server.TUS_VERSION)
         # Transport-level rejections short-circuit before the core, so add CORS
         # here too — otherwise a browser can't read the status of a 400/413 that
-        # the chunked-body parser or size gate produced (cross-origin opaque).
+        # the body parser or the Content-Length size gates produced: the
+        # response is opaque cross-origin and surfaces as a network error.
         origin = self.headers.get("Origin")
         for key, value in self.tus_server._add_cors_headers({}, origin=origin).items():
             self.send_header(key, value)
@@ -172,30 +173,18 @@ class TusHTTPRequestHandler(BaseHTTPRequestHandler):
             try:
                 content_length = int(self.headers.get("Content-Length", 0))
             except (ValueError, TypeError):
-                self.send_response(400)
-                self.send_header("Tus-Resumable", self.tus_server.TUS_VERSION)
-                self.end_headers()
-                self.wfile.write(b"Invalid Content-Length header")
+                self._send_error(400, b"Invalid Content-Length header")
                 return
             if content_length < 0:
-                self.send_response(400)
-                self.send_header("Tus-Resumable", self.tus_server.TUS_VERSION)
-                self.end_headers()
-                self.wfile.write(b"Content-Length must not be negative")
+                self._send_error(400, b"Content-Length must not be negative")
                 return
             max_size = self.tus_server.max_size
             if max_size > 0 and content_length > max_size:
-                self.send_response(413)
-                self.send_header("Tus-Resumable", self.tus_server.TUS_VERSION)
-                self.end_headers()
-                self.wfile.write(b"Request entity too large")
+                self._send_error(413, b"Request entity too large")
                 return
             max_chunk = self.tus_server.max_chunk_size
             if method == "PATCH" and max_chunk > 0 and content_length > max_chunk:
-                self.send_response(413)
-                self.send_header("Tus-Resumable", self.tus_server.TUS_VERSION)
-                self.end_headers()
-                self.wfile.write(b"Chunk exceeds maximum chunk size")
+                self._send_error(413, b"Chunk exceeds maximum chunk size")
                 return
             if content_length > 0:
                 body = self.rfile.read(content_length)

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -128,3 +128,75 @@ class TestMaxAge:
         )
         assert status == 201
         assert "Access-Control-Max-Age" not in headers
+
+
+class TestTransportRejectionsCarryCORS:
+    """The handler's own 400/413 gates short-circuit before the core.
+
+    tus-js-client and uppy send Content-Length, not chunked, so these are the
+    rejections a browser actually hits — without CORS the response is opaque
+    cross-origin and the client reports a generic network error, not the status.
+    """
+
+    @pytest.fixture
+    def port(self, storage):
+        import threading
+        from http.server import HTTPServer
+
+        from resumable_upload.server import TusHTTPRequestHandler
+
+        tus = TusServer(
+            storage=storage,
+            base_path="/files",
+            cors_allow_origins="https://app.example",
+            max_chunk_size=1024,
+            max_size=8192,
+        )
+
+        class Handler(TusHTTPRequestHandler):
+            tus_server = tus
+
+        server = HTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            yield server.server_address[1]
+        finally:
+            server.shutdown()
+            server.server_close()
+
+    def _patch(self, port, body, content_length):
+        import urllib.error
+        import urllib.request
+
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/files/nonexistent",
+            data=body,
+            method="PATCH",
+            headers={
+                "Tus-Resumable": "1.0.0",
+                "Upload-Offset": "0",
+                "Content-Type": "application/offset+octet-stream",
+                "Content-Length": str(content_length),
+                "Origin": "https://app.example",
+            },
+        )
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return resp.status, resp.headers
+        except urllib.error.HTTPError as e:
+            return e.code, e.headers
+
+    def test_chunk_over_cap_is_readable_cross_origin(self, port):
+        status, headers = self._patch(port, b"x" * 2048, 2048)
+        assert status == 413
+        assert headers["Access-Control-Allow-Origin"] == "https://app.example"
+
+    def test_body_over_max_size_is_readable_cross_origin(self, port):
+        status, headers = self._patch(port, b"x" * 9000, 9000)
+        assert status == 413
+        assert headers["Access-Control-Allow-Origin"] == "https://app.example"
+
+    def test_malformed_content_length_is_readable_cross_origin(self, port):
+        status, headers = self._patch(port, b"", "not-a-number")
+        assert status == 400
+        assert headers["Access-Control-Allow-Origin"] == "https://app.example"


### PR DESCRIPTION
## Purpose

_send_error gained CORS headers, but only the chunked-body parser used it; the malformed/negative Content-Length and the max_size/max_chunk_size gates still wrote their own bare responses. tus-js-client and uppy send Content-Length, so those were the rejections a browser actually hit, and it saw an opaque cross-origin response instead of the 400/413.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
