### PR TITLE
fix(client): keep the httpx client alive for a borrowed AsyncUploader

### DIFF
--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -275,7 +275,7 @@ that point the client stays open and you own it:
 client = AsyncTusClient(url)
 uploader = await client.create_uploader("large_file.bin")
 await uploader.upload()
-await client.aclose()          # your job once you have borrowed the client
+await client.aclose()  # your job once you have borrowed the client
 ```
 
 ### AsyncUploader

--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -264,6 +264,20 @@ the file is split into N byte ranges and uploaded concurrently via `asyncio.gath
 `find_previous_uploads` stays synchronous — it is a pure local fingerprint
 lookup with no I/O, so there is no async variant.
 
+#### Client lifetime
+
+Inside `async with`, the httpx client lives for the block. Outside it, each
+call opens the client and closes it again on the way out — except
+`create_uploader`, which hands the live client to the `AsyncUploader`. From
+that point the client stays open and you own it:
+
+```python
+client = AsyncTusClient(url)
+uploader = await client.create_uploader("large_file.bin")
+await uploader.upload()
+await client.aclose()          # your job once you have borrowed the client
+```
+
 ### AsyncUploader
 
 ```python

--- a/resumable_upload/client/aio/client.py
+++ b/resumable_upload/client/aio/client.py
@@ -26,6 +26,10 @@ def _managed(method):
     public entry point opens the httpx client lazily and must close it, or the
     connection pool leaks. A depth counter makes nested public calls (e.g.
     parallel upload -> create_partial_upload) close only at the outermost one.
+
+    ``create_uploader`` hands the live client to an ``AsyncUploader`` that
+    outlives the call, so it marks the client borrowed and auto-close stands
+    down — the caller owns ``aclose()`` from then on.
     """
 
     @functools.wraps(method)
@@ -37,7 +41,7 @@ def _managed(method):
             return await method(self, *args, **kwargs)
         finally:
             self._call_depth -= 1
-            if self._call_depth == 0:
+            if self._call_depth == 0 and not self._client_borrowed:
                 await self.aclose()
 
     return wrapper
@@ -130,6 +134,7 @@ class AsyncTusClient:
         self._client: Any | None = None  # httpx.AsyncClient, built lazily
         self._entered = False  # True while inside `async with`
         self._call_depth = 0  # nesting depth for standalone auto-close
+        self._client_borrowed = False  # True once an AsyncUploader holds the client
 
     # ------------------------------------------------------------------
     # Async context manager
@@ -149,6 +154,7 @@ class AsyncTusClient:
         if self._client is not None:
             await self._client.aclose()
             self._client = None
+        self._client_borrowed = False
 
     # ------------------------------------------------------------------
     # Internal helpers
@@ -670,6 +676,11 @@ class AsyncTusClient:
             metadata: Metadata dictionary (only used when creating a new upload).
             chunk_size: Chunk size override (uses client default when None).
 
+        The uploader borrows this client's httpx connection pool rather than
+        opening its own, so on a standalone client (no ``async with``) the
+        usual auto-close is suspended from here on: call ``aclose()`` when the
+        uploader is done, or use ``async with`` and let it close for you.
+
         Returns:
             An AsyncUploader ready to call ``upload()`` on.
 
@@ -694,6 +705,9 @@ class AsyncTusClient:
 
         actual_chunk_size = chunk_size if chunk_size is not None else self.chunk_size
         client = await self._ensure_client()
+        # The uploader outlives this call and uses the client directly, so
+        # standalone auto-close must stand down; the caller closes the client.
+        self._client_borrowed = True
         return await AsyncUploader.open(
             client,
             upload_url,

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -300,3 +300,29 @@ async def test_async_deferred_length_commits(asgi_base):
         head = await c.request("HEAD", url, headers={"Tus-Resumable": "1.0.0"})
         assert head.headers["Upload-Offset"] == str(len(data))
         assert head.headers["Upload-Length"] == str(len(data))
+
+
+@pytest.mark.anyio
+async def test_standalone_call_keeps_uploader_client_alive(asgi_base, tmp_path):
+    """create_uploader hands out the httpx client; auto-close must not reclaim it.
+
+    Outside `async with`, every @_managed method closes the client on its way
+    out. An AsyncUploader borrowed from create_uploader holds that same client,
+    so a plain get_upload_info between the two calls used to close it under the
+    uploader's feet.
+    """
+    import os
+
+    from resumable_upload.client.aio.client import AsyncTusClient
+
+    transport, base = asgi_base
+    f = tmp_path / "data.bin"
+    payload = os.urandom(20_000)
+    f.write_bytes(payload)
+
+    client = AsyncTusClient(base, _transport=transport, chunk_size=4096)
+    uploader = await client.create_uploader(str(f))
+    assert (await client.get_upload_info(uploader.url))["offset"] == 0
+    await uploader.upload()
+    assert (await client.get_upload_info(uploader.url))["offset"] == len(payload)
+    await client.aclose()


### PR DESCRIPTION
## Purpose

create_uploader hands the live httpx client to the AsyncUploader, but on a standalone client every other @_managed method closed it on the way out, so a get_upload_info between create_uploader and upload() killed the pool the uploader still held. Mark the client borrowed and stand auto-close down; the caller owns aclose() from that point.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
