### PR TITLE
docs: scope the cloud CAS claim and surface the default lock backend

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -257,6 +257,8 @@ final_url = client.create_final_upload(
 
 **`TusServer`**: `storage`, `base_path` (기본값 `/files`), `max_size`, `upload_expiry`, `cors_allow_origins`, `request_timeout` (기본값 30s — Slowloris 공격 방어) — 프록시/`Location` 설정, CORS 자격 증명, 다운로드, 체크섬 트레일러, 기능 토글 등 전체 목록: **[서버 API 레퍼런스](https://injaeryou.github.io/resumable-upload/api-reference/server/)**
 
+**`lock_backend`**: `TusServer`는 기본으로 in-process `InMemoryLockBackend`를 설치하므로 한 업로드에 대한 동시 `PATCH`/`DELETE`가 프로세스 안에서 직렬화됩니다 — `lock_wait_seconds`(5초)를 넘기면 진 쪽은 **`423 Locked`**를 받습니다. 멀티프로세스·멀티노드 배포는 `RedisLockBackend`를 넘겨야 합니다. 끄려면 `lock_backend=None`을 넘기거나, 락이 없는 `TusServerCore`를 쓰세요: **[락 백엔드](https://injaeryou.github.io/resumable-upload/operations/locks/)**
+
 **`SQLiteStorage`**: `db_path` (기본값 `uploads.db`), `upload_dir` (기본값 `uploads`) — 업로드별 락으로 스레드 안전; `fcntl.flock`으로 프로세스 안전
 
 **`FileURLStorage`**: `storage_path` (기본값 `.tus_urls.json`) — `threading.Lock`으로 스레드 안전; `fcntl.flock`으로 프로세스 안전

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Full API documentation is available on the docs site: [Client](https://injaeryou
 
 **`TusServer`**: `storage`, `base_path` (default `/files`), `max_size`, `upload_expiry`, `cors_allow_origins`, `request_timeout` (default 30s — Slowloris protection) — plus proxy/`Location` config, CORS credentials, downloads, checksum trailers, feature toggles, and more: **[server API reference](https://injaeryou.github.io/resumable-upload/api-reference/server/)**
 
+**`lock_backend`**: `TusServer` installs an in-process `InMemoryLockBackend` by default, so concurrent `PATCH`/`DELETE` on one upload are serialized within a process — beyond `lock_wait_seconds` (5s) the loser gets **`423 Locked`**. Multi-process or multi-node deployments must pass a `RedisLockBackend`; pass `lock_backend=None` to opt out, or use `TusServerCore`, which stays lock-free: **[lock backends](https://injaeryou.github.io/resumable-upload/operations/locks/)**
+
 **`SQLiteStorage`**: `db_path` (default `uploads.db`), `upload_dir` (default `uploads`) — thread-safe via per-upload lock; process-safe via `fcntl.flock`
 
 **`FileURLStorage`**: `storage_path` (default `.tus_urls.json`) — thread-safe via `threading.Lock`; process-safe via `fcntl.flock`

--- a/docs/api-reference/storage.md
+++ b/docs/api-reference/storage.md
@@ -115,7 +115,7 @@ For small files (all data fits in the buffer), a single `PutObject` is used inst
 
 Concatenation is implemented via `UploadPartCopy` so partial-to-final merge happens entirely on the S3 side.
 
-`update_offset_atomic()` writes the offset back under an `If-Match` on the info object's ETag, so a concurrent writer on another node loses with `412` and gets `False` instead of silently overwriting the winner.
+`update_offset_atomic()` writes the offset back under an `If-Match` on the info object's ETag, so a concurrent writer on another node loses with `412` and gets `False` instead of silently overwriting the winner. Note that `write_chunk()` rewrites the same info object unconditionally, so the CAS only serializes the offset write itself — two PATCHes racing across processes still need a [lock backend](../operations/locks.md).
 
 ```python
 storage.complete_upload(upload_id)  # Assembles the final S3 object
@@ -153,7 +153,7 @@ storage = GCSStorage(
 
 Chunks are buffered and flushed as individual part blobs. On `complete_upload()`, parts are assembled using GCS `compose()` (handles the 32-object limit via hierarchical composition). For small files, a direct upload is used. Concatenation also uses `compose()`.
 
-`update_offset_atomic()` writes the offset back with `if_generation_match`, so a concurrent writer on another node loses with `412` and gets `False` instead of silently overwriting the winner.
+`update_offset_atomic()` writes the offset back with `if_generation_match`, so a concurrent writer on another node loses with `412` and gets `False` instead of silently overwriting the winner. Note that `write_chunk()` rewrites the same info object unconditionally, so the CAS only serializes the offset write itself — two PATCHes racing across processes still need a [lock backend](../operations/locks.md).
 
 ```python
 storage.complete_upload(upload_id)
@@ -192,7 +192,7 @@ storage = AzureBlobStorage(
 
 Chunks are buffered and staged as Azure blocks via `stage_block()`. On `complete_upload()`, all blocks are committed via `commit_block_list()` to form the final blob. For small files, a direct `upload_blob()` is used. Concatenation reuses the block-list mechanism — partials are committed by referencing their staged blocks in the final blob's block list.
 
-`update_offset_atomic()` writes the offset back under `MatchConditions.IfNotModified` on the info blob's ETag, so a concurrent writer on another node loses and gets `False` instead of silently overwriting the winner.
+`update_offset_atomic()` writes the offset back under `MatchConditions.IfNotModified` on the info blob's ETag, so a concurrent writer on another node loses and gets `False` instead of silently overwriting the winner. Note that `write_chunk()` rewrites the same info object unconditionally, so the CAS only serializes the offset write itself — two PATCHes racing across processes still need a [lock backend](../operations/locks.md).
 
 ```python
 storage.complete_upload(upload_id)

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -82,7 +82,7 @@ Compliance status against the [TUS resumable upload protocol v1.0.0](https://tus
 | `Upload-Checksum` (configurable algorithm) | ✅ | `sha1` default; `sha256`, `sha512`, `md5` opt-in |
 | Cross-session URL persistence (fingerprint-based) | ✅ | `FileURLStorage` / `SQLiteURLStorage` / `InMemoryURLStorage` |
 | Full-file fingerprint (not just first 64 KB) | ✅ | SHA-256 of entire content (default; `PartialMD5Fingerprint` and `CallableFingerprint` available) |
-| `409` on concurrent offset conflict (atomic CAS) | ✅ | Every backend does a real compare-and-swap: SQLite `UPDATE ... WHERE offset = ?`, S3/Azure conditional write on the info object's ETag, GCS `if_generation_match`. Returns `409` when the CAS loses. |
+| `409` on concurrent offset conflict (atomic CAS) | ✅ | Every backend does a real compare-and-swap: SQLite `UPDATE ... WHERE offset = ?`, S3/Azure conditional write on the info object's ETag, GCS `if_generation_match`. Returns `409` when the CAS loses. On the cloud backends the CAS covers the offset write alone — `write_chunk` rewrites the whole info object, so a **cross-process** PATCH pair still needs a [lock backend](operations/locks.md) to be serialized. SQLite keeps the offset in its own column and is atomic without one. |
 | `409` received → HEAD re-sync before retry | ✅ | Client fetches current offset and re-seeks before retrying chunk |
 | Parallel concatenation upload | ✅ | `parallel_uploads=N` on `upload_file()` |
 | Manual partial / final concatenation primitives | ✅ | `create_partial_upload()` / `create_final_upload()` |

--- a/resumable_upload/storage/azure_storage.py
+++ b/resumable_upload/storage/azure_storage.py
@@ -204,6 +204,13 @@ class AzureBlobStorage(Storage):
         # if it hasn't changed (If-Match). A concurrent writer that already
         # advanced the offset changes the ETag, so the loser's conditional
         # upload raises ResourceModifiedError and returns False (invariant #6).
+        #
+        # Scope: this guards the offset write only. write_chunk() rewrites the
+        # same info object unconditionally from a snapshot taken at its start,
+        # so two PATCHes racing across processes can still lose an update; a
+        # LockBackend is what serializes that pair. Folding the chunk write and
+        # the offset commit into a single conditional write would remove the
+        # need for one.
         from azure.storage.blob import ContentSettings
 
         blob = self._get_blob_client(self._info_key(upload_id))

--- a/resumable_upload/storage/gcs_storage.py
+++ b/resumable_upload/storage/gcs_storage.py
@@ -171,6 +171,13 @@ class GCSStorage(Storage):
         # only if the object hasn't changed since we read it. A concurrent
         # writer that already advanced the offset bumps the generation, so the
         # losing if_generation_match write gets 412 and returns False.
+        #
+        # Scope: this guards the offset write only. write_chunk() rewrites the
+        # same info object unconditionally from a snapshot taken at its start,
+        # so two PATCHes racing across processes can still lose an update; a
+        # LockBackend is what serializes that pair. Folding the chunk write and
+        # the offset commit into a single conditional write would remove the
+        # need for one.
         blob = self.gcs_bucket.get_blob(self._info_key(upload_id))
         if blob is None:
             return False

--- a/resumable_upload/storage/s3_storage.py
+++ b/resumable_upload/storage/s3_storage.py
@@ -173,6 +173,13 @@ class S3Storage(Storage):
         # back only if it hasn't changed (S3 If-Match). Two concurrent writers
         # that both read offset==expected can't both win — the second's
         # conditional PUT gets 412 and returns False (TUS invariant #6).
+        #
+        # Scope: this guards the offset write only. write_chunk() rewrites the
+        # same info object unconditionally from a snapshot taken at its start,
+        # so two PATCHes racing across processes can still lose an update; a
+        # LockBackend is what serializes that pair. Folding the chunk write and
+        # the offset commit into a single conditional write would remove the
+        # need for one.
         try:
             resp = self.s3.get_object(Bucket=self.bucket, Key=self._info_key(upload_id))
         except ClientError as e:


### PR DESCRIPTION
## Purpose

The compliance and storage pages read as though the CAS makes a lock backend optional. It does not on the cloud backends: write_chunk rewrites the same info object unconditionally, so the CAS serializes the offset write alone and a cross-process PATCH pair still needs a LockBackend. Note the ceiling next to each implementation.

TusServer's InMemoryLockBackend default was documented only under operations; concurrent PATCH now yields 423 rather than proceeding.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
