### PR TITLE
fix(storage): map lost cloud CAS races to 409 instead of raising

### DIFF
--- a/resumable_upload/storage/gcs_storage.py
+++ b/resumable_upload/storage/gcs_storage.py
@@ -181,7 +181,16 @@ class GCSStorage(Storage):
         blob = self.gcs_bucket.get_blob(self._info_key(upload_id))
         if blob is None:
             return False
-        info = json.loads(blob.download_as_bytes())
+        try:
+            # get_blob() pins this handle to a specific generation (the fetched
+            # media_link carries it), so the download asks for *that* generation
+            # rather than "current". A writer that overwrites the object in the
+            # window since the fetch retires that generation — on a bucket
+            # without object versioning it is gone and GCS answers 404. That is
+            # a lost race, not a missing upload: report it as one.
+            info = json.loads(blob.download_as_bytes())
+        except NotFound:
+            return False
         if info["offset"] != expected_offset:
             return False
         info["offset"] = new_offset

--- a/resumable_upload/storage/s3_storage.py
+++ b/resumable_upload/storage/s3_storage.py
@@ -199,7 +199,16 @@ class S3Storage(Storage):
                 IfMatch=resp["ETag"],
             )
         except ClientError as e:
-            if e.response["Error"]["Code"] in ("PreconditionFailed", "412"):
+            # 412 is the stale-ETag answer. 409 ConditionalRequestConflict is
+            # the *concurrent* one: S3 documents it for a conditional PutObject
+            # that races another conditional write to the same key, and tells
+            # callers to re-fetch the ETag and retry. Both mean "we lost".
+            if e.response["Error"]["Code"] in (
+                "PreconditionFailed",
+                "412",
+                "ConditionalRequestConflict",
+                "409",
+            ):
                 return False
             raise
         return True

--- a/tests/test_storage_gcs.py
+++ b/tests/test_storage_gcs.py
@@ -32,6 +32,14 @@ class FakeBlob:
 
         if self.name not in self._bucket._blobs:
             raise NotFound(f"Blob {self.name} not found")
+        # A handle from get_blob() is pinned to the generation it fetched (the
+        # real media_link carries it), so the download asks for that exact
+        # generation. Without object versioning an overwrite retires it and
+        # GCS answers 404 — model that, or the CAS race path stays untested.
+        if self.generation is not None and self.generation != self._bucket._generations.get(
+            self.name
+        ):
+            raise NotFound(f"Blob {self.name} generation {self.generation} is gone")
         return self._bucket._blobs[self.name]
 
     def delete(self):
@@ -318,6 +326,34 @@ class TestGCSStorageOffset:
             FakeBlob.download_as_bytes = real_download
         assert raced, "the rival write never interleaved; the test proved nothing"
         assert storage.get_upload("cas-race")["offset"] == 40
+
+    def test_update_offset_atomic_loses_race_before_the_read(self, storage, gcs_client):
+        """Losing the race *before* the download is still a lost race, not a 500.
+
+        The rival commits between get_blob() and download_as_bytes(), retiring
+        the generation this handle is pinned to. GCS answers 404 for a gone
+        generation, so the download raises NotFound — which must surface as
+        False (-> 409 Conflict) rather than escaping and becoming a 500.
+        """
+        storage.create_upload("cas-early", 100, {})
+        bucket = gcs_client.bucket(TEST_BUCKET)
+        real_get_blob = bucket.get_blob
+        raced = []
+
+        def get_blob_then_let_rival_win(name):
+            blob = real_get_blob(name)
+            if blob is not None and not raced:
+                raced.append(True)
+                storage.update_offset("cas-early", 40)  # retires our generation
+            return blob
+
+        bucket.get_blob = get_blob_then_let_rival_win
+        try:
+            assert storage.update_offset_atomic("cas-early", 0, 50) is False
+        finally:
+            bucket.get_blob = real_get_blob
+        assert raced, "the rival write never interleaved; the test proved nothing"
+        assert storage.get_upload("cas-early")["offset"] == 40
 
 
 # -- File info ---------------------------------------------------------------

--- a/tests/test_storage_s3.py
+++ b/tests/test_storage_s3.py
@@ -202,6 +202,37 @@ class TestS3StorageOffset:
         assert raced, "the rival write never interleaved; the test proved nothing"
         assert storage.get_upload("cas-race")["offset"] == 40
 
+    @pytest.mark.parametrize("code", ["ConditionalRequestConflict", "409"])
+    def test_update_offset_atomic_maps_conditional_conflict(self, storage, code):
+        """409 ConditionalRequestConflict is a lost race, not a server error.
+
+        S3 documents it for a conditional PutObject that races another
+        conditional write to the same key ("On a 409 failure, retry"). moto
+        only ever produces 412, so this path needs an injected error or it
+        escapes update_offset_atomic entirely.
+
+        Scope: this asserts the storage-level contract (a lost race is False,
+        not an exception). Turning False into the 409 response lives in
+        handlers/patch.py and is covered there.
+        """
+        from botocore.exceptions import ClientError
+
+        storage.create_upload("cas-409", 100, {})
+        real_put_object = storage.s3.put_object
+
+        def put_object_conflicts(**kwargs):
+            raise ClientError(
+                {"Error": {"Code": code, "Message": "conflicting conditional write"}},
+                "PutObject",
+            )
+
+        storage.s3.put_object = put_object_conflicts
+        try:
+            assert storage.update_offset_atomic("cas-409", 0, 50) is False
+        finally:
+            storage.s3.put_object = real_put_object
+        assert storage.get_upload("cas-409")["offset"] == 0
+
 
 # -- File info ---------------------------------------------------------------
 


### PR DESCRIPTION
## Purpose

Both cloud backends could escape update_offset_atomic on a lost race, turning the 409 Conflict TUS invariant #6 requires into a 500.

GCS: get_blob() pins the handle to a generation and the download asks for that generation, not "current". A writer that overwrites the info object in the window retires it; without object versioning it is gone and GCS answers 404, so NotFound propagated out. Catch it — losing the race before the read is still losing the race.

S3: a conditional PutObject answers 409 ConditionalRequestConflict when it races another conditional write to the same key, not just 412 on a stale ETag. Only 412 was mapped, so the 409 re-raised.

Neither path was reachable in tests: the GCS fake read the current value regardless of the handle's generation, and moto never produces the 409. The fake now models generation pinning; the 409 is injected.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
