### PR TITLE
fix(server): stop async lock waiters from starving the lock holder

### DIFF
--- a/docs/operations/locks.md
+++ b/docs/operations/locks.md
@@ -67,6 +67,7 @@ from resumable_upload.locks import LockBackend
 class MyLockBackend(LockBackend):
     def acquire(self, key: str, ttl_seconds: float, wait_timeout: float = 0.0) -> str | None:
         # Return a non-empty token on success, None on contention/timeout.
+        # wait_timeout=0.0 MUST return immediately — see below.
         ...
 
     def release(self, key: str, token: str) -> None:
@@ -75,3 +76,38 @@ class MyLockBackend(LockBackend):
 ```
 
 The `acquire` token is a capability for `release` — the server passes back exactly the value it received. Implementations must enforce `ttl_seconds` so a crashed holder's lock eventually expires without external intervention.
+
+!!! warning "`wait_timeout=0.0` must not block"
+
+    This is a hard requirement, not a convention. `LockBackend.acquire_async` — which
+    the async server path (`handle_request_async`, `TusASGIApp`) uses — bridges your
+    sync `acquire` by *polling* it with `wait_timeout=0.0` and awaiting between
+    attempts. A single attempt hops to a worker thread; the waiting happens on the
+    event loop.
+
+    Note that this is the opposite of some familiar conventions, where a zero or
+    absent timeout means "block until acquired" (`threading.Lock.acquire(timeout=-1)`,
+    redis-py's `Lock(blocking_timeout=None)`). If your `acquire` blocks on
+    `wait_timeout=0.0`, the async path pins an executor worker per waiter for as long
+    as it blocks — `lock_wait_seconds` is silently ignored, `423 Locked` is never
+    returned, and because the lock *holder*'s storage calls draw from that same
+    default executor, enough waiters will starve the very holder that would release
+    them.
+
+### Overriding the async path
+
+`acquire_async` / `release_async` are ordinary methods with working defaults, so a
+sync-only `acquire` / `release` pair is enough. Override them when your coordinator
+has a native async client, or to skip the thread hop entirely:
+
+```python
+class MyLockBackend(LockBackend):
+    async def acquire_async(
+        self, key: str, ttl_seconds: float, wait_timeout: float = 0.0
+    ) -> str | None: ...
+
+    async def release_async(self, key: str, token: str) -> None: ...
+```
+
+`InMemoryLockBackend` does exactly this — its state is a dict behind a mutex held for
+microseconds, so it polls inline and leaves the executor free.

--- a/resumable_upload/locks/base.py
+++ b/resumable_upload/locks/base.py
@@ -9,7 +9,12 @@ pluggable lock without caring where the authoritative state lives.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from abc import ABC, abstractmethod
+
+#: How long the async waiter sleeps between acquisition attempts.
+_POLL_INTERVAL = 0.02
 
 
 class LockBackend(ABC):
@@ -22,6 +27,9 @@ class LockBackend(ABC):
       stale / wrong token or on a key that is not currently held.
     - Implementations must honor ``ttl_seconds`` so a crashed holder's lock
       eventually expires without external intervention.
+    - ``acquire`` with ``wait_timeout=0`` must not block: it either takes the
+      lock immediately or returns ``None``. ``acquire_async`` relies on that
+      to poll without pinning a worker thread.
     """
 
     @abstractmethod
@@ -34,3 +42,50 @@ class LockBackend(ABC):
 
     @abstractmethod
     def release(self, key: str, token: str) -> None: ...
+
+    async def acquire_async(
+        self,
+        key: str,
+        ttl_seconds: float,
+        wait_timeout: float = 0.0,
+    ) -> str | None:
+        """Async sibling of :meth:`acquire`.
+
+        Handing the *blocking* ``acquire`` to ``asyncio.to_thread`` would pin
+        a worker of the loop's default executor for the whole ``wait_timeout``
+        — and the lock *holder*'s storage calls draw from that same pool, so
+        enough waiters starve the holder that would release them. Poll the
+        non-blocking form instead: each hop occupies a thread only for the
+        acquisition attempt itself, and the waiting happens on the event loop.
+
+        Cancellation (an ASGI host dropping the request when the client
+        disconnects) can land while an attempt is in flight. A thread cannot be
+        interrupted, so that attempt may still take the lock after we are gone —
+        the token would be lost and the upload stay locked for the whole TTL.
+        Shield the attempt and release whatever it won on the way out.
+        """
+        deadline = time.monotonic() + wait_timeout
+        while True:
+            attempt = asyncio.ensure_future(asyncio.to_thread(self.acquire, key, ttl_seconds, 0.0))
+            try:
+                token = await asyncio.shield(attempt)
+            except asyncio.CancelledError:
+                attempt.add_done_callback(lambda t: self._discard_orphan(key, t))
+                raise
+            if token is not None:
+                return token
+            if time.monotonic() >= deadline:
+                return None
+            await asyncio.sleep(_POLL_INTERVAL)
+
+    async def release_async(self, key: str, token: str) -> None:
+        """Async sibling of :meth:`release`."""
+        await asyncio.to_thread(self.release, key, token)
+
+    def _discard_orphan(self, key: str, attempt: asyncio.Future) -> None:
+        """Release a lock won by an attempt whose waiter was already cancelled."""
+        if attempt.cancelled() or attempt.exception() is not None:
+            return
+        token = attempt.result()
+        if token is not None:
+            self.release(key, token)

--- a/resumable_upload/locks/memory_lock.py
+++ b/resumable_upload/locks/memory_lock.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import secrets
 import threading
 import time
 
-from resumable_upload.locks.base import LockBackend
+from resumable_upload.locks.base import _POLL_INTERVAL, LockBackend
 
 
 class InMemoryLockBackend(LockBackend):
@@ -40,10 +41,32 @@ class InMemoryLockBackend(LockBackend):
                     return token
             if time.monotonic() >= deadline:
                 return None
-            time.sleep(0.02)
+            time.sleep(_POLL_INTERVAL)
 
     def release(self, key: str, token: str) -> None:
         with self._lock:
             entry = self._holders.get(key)
             if entry is not None and entry[0] == token:
                 del self._holders[key]
+
+    async def acquire_async(
+        self,
+        key: str,
+        ttl_seconds: float,
+        wait_timeout: float = 0.0,
+    ) -> str | None:
+        # The base implementation is correct here, but every attempt would
+        # cost a thread hop. This backend's state is a dict behind a mutex
+        # held for microseconds and never across an await, so poll it inline
+        # and keep the executor free entirely.
+        deadline = time.monotonic() + wait_timeout
+        while True:
+            token = self.acquire(key, ttl_seconds, 0.0)
+            if token is not None:
+                return token
+            if time.monotonic() >= deadline:
+                return None
+            await asyncio.sleep(_POLL_INTERVAL)
+
+    async def release_async(self, key: str, token: str) -> None:
+        self.release(key, token)

--- a/resumable_upload/server/core.py
+++ b/resumable_upload/server/core.py
@@ -1,6 +1,5 @@
 """TUS protocol server implementation."""
 
-import asyncio
 import logging
 import threading
 from collections.abc import Awaitable
@@ -349,14 +348,17 @@ class TusServerCore:
         upload_id: str,
         fn: Callable[[], Awaitable[tuple[int, dict, bytes]]],
     ) -> tuple[int, dict, bytes]:
-        """Async sibling of :meth:`_with_lock`. ``LockBackend`` stays sync;
-        ``acquire``/``release`` run on a worker thread while the wrapped
-        coroutine is awaited under the held lock.
+        """Async sibling of :meth:`_with_lock`.
+
+        Goes through :meth:`LockBackend.acquire_async`, which waits on the event
+        loop rather than pinning a worker thread for the whole ``wait_timeout``.
+        That matters because the lock *holder*'s storage ``*_async`` calls draw
+        from the same default executor: a queue of waiters holding it would
+        starve the very holder that would release them.
         """
         if self._locks is None:
             return await fn()
-        token = await asyncio.to_thread(
-            self._locks.acquire,
+        token = await self._locks.acquire_async(
             upload_id,
             ttl_seconds=self._lock_ttl,
             wait_timeout=self._lock_wait,
@@ -366,7 +368,7 @@ class TusServerCore:
         try:
             return await fn()
         finally:
-            await asyncio.to_thread(self._locks.release, upload_id, token)
+            await self._locks.release_async(upload_id, token)
 
     def _add_cors_headers(
         self, headers: dict, origin: Optional[str] = None, preflight: bool = False

--- a/resumable_upload/server/server.py
+++ b/resumable_upload/server/server.py
@@ -27,6 +27,13 @@ class TusServer(TusServerCore):
     multi-node deployments must pass an explicit distributed lock**
     (``RedisLockBackend``); pass ``lock_backend=None`` to opt out entirely.
 
+    The guarantee is bounded by ``lock_ttl_seconds`` (60s by default): a lock
+    is reclaimable once its TTL expires, so a PATCH whose chunk write outruns
+    the TTL can be joined by a second one and interleave exactly as above. The
+    first holder's ``release`` then no-ops on the token mismatch, silently.
+    Raise ``lock_ttl_seconds`` past your slowest expected chunk write when
+    chunks are large or the storage backend is remote.
+
     Reserve ``TusServerCore`` for downstream code that wants the minimal,
     lock-free surface.
     """

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -6,12 +6,14 @@ acquire/release/TTL/token-mismatch contract.
 
 from __future__ import annotations
 
+import asyncio
 import threading
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
 
-from resumable_upload.locks import InMemoryLockBackend
+from resumable_upload.locks import InMemoryLockBackend, LockBackend
 
 _IMPLS: list[str] = ["memory"]
 
@@ -38,6 +40,24 @@ def _make(impl: str):
 @pytest.fixture(params=_IMPLS)
 def lock(request):
     return _make(request.param)
+
+
+class PlainLockBackend(LockBackend):
+    """A backend that inherits the BASE ``acquire_async`` — like ``RedisLockBackend``.
+
+    ``InMemoryLockBackend`` overrides the async path to skip the executor
+    entirely, so it can never exercise the generic bridge. Tests that care
+    about the bridge use this instead.
+    """
+
+    def __init__(self) -> None:
+        self._inner = InMemoryLockBackend()
+
+    def acquire(self, key, ttl_seconds, wait_timeout=0.0):
+        return self._inner.acquire(key, ttl_seconds, wait_timeout)
+
+    def release(self, key, token):
+        self._inner.release(key, token)
 
 
 class TestLockBackendContract:
@@ -211,3 +231,222 @@ class TestInMemoryLockConcurrency:
 
         # The original acquirer holds it; all 5 racing threads time out
         assert winners.count(None) == 5
+
+
+class TestAsyncLockContract:
+    """``acquire_async`` / ``release_async`` must match the sync contract."""
+
+    def test_acquire_async_then_release_async(self, lock):
+        async def scenario():
+            token = await lock.acquire_async("a-1", ttl_seconds=5)
+            assert token is not None
+            await lock.release_async("a-1", token)
+            return await lock.acquire_async("a-1", ttl_seconds=5)
+
+        assert asyncio.run(scenario()) is not None
+
+    def test_acquire_async_times_out_when_held(self, lock):
+        async def scenario():
+            assert lock.acquire("a-2", ttl_seconds=5) is not None
+            return await lock.acquire_async("a-2", ttl_seconds=5, wait_timeout=0.1)
+
+        assert asyncio.run(scenario()) is None
+
+    def test_acquire_async_gets_lock_once_released(self, lock):
+        async def scenario():
+            token = lock.acquire("a-3", ttl_seconds=5)
+
+            async def release_soon():
+                await asyncio.sleep(0.05)
+                lock.release("a-3", token)
+
+            waiter = asyncio.create_task(lock.acquire_async("a-3", ttl_seconds=5, wait_timeout=2.0))
+            await release_soon()
+            return await waiter
+
+        assert asyncio.run(scenario()) is not None
+
+
+class TestAsyncLockDoesNotPinThreads:
+    """Waiters must not hold executor threads for the whole wait_timeout.
+
+    ``_with_lock_async`` awaits the lock on the same default executor the
+    holder's storage calls (``write_chunk_async`` and friends) draw from. If a
+    waiter blocks a worker for its full ``lock_wait_seconds``, enough waiters
+    starve the very holder that would release them.
+    """
+
+    def test_waiters_leave_the_default_executor_free(self):
+        # Deliberately NOT InMemoryLockBackend: its acquire_async override never
+        # touches the executor, so it cannot fail here by construction. This has
+        # to run against the generic bridge every third-party backend inherits.
+        lock = PlainLockBackend()
+        assert lock.acquire("busy", ttl_seconds=10) is not None
+
+        async def scenario():
+            # Fewer workers than waiters: if a waiter pins one, the probe below
+            # cannot get a thread until some waiter gives up.
+            loop = asyncio.get_running_loop()
+            loop.set_default_executor(ThreadPoolExecutor(max_workers=2))
+
+            waiters = [
+                asyncio.create_task(lock.acquire_async("busy", ttl_seconds=10, wait_timeout=3.0))
+                for _ in range(4)
+            ]
+            await asyncio.sleep(0.1)  # let every waiter reach its wait
+
+            t0 = time.monotonic()
+            probe = await asyncio.to_thread(lambda: "storage call")
+            elapsed = time.monotonic() - t0
+
+            for w in waiters:
+                w.cancel()
+            await asyncio.gather(*waiters, return_exceptions=True)
+            return probe, elapsed
+
+        probe, elapsed = asyncio.run(scenario())
+        assert probe == "storage call"
+        assert elapsed < 1.0, (
+            f"a to_thread call queued behind lock waiters for {elapsed:.2f}s; "
+            "waiters are pinning the default executor"
+        )
+
+    def test_base_acquire_async_only_polls_non_blocking(self):
+        """The generic bridge must never hand a blocking wait to a thread."""
+        seen: list[float] = []
+
+        class RecordingLock(LockBackend):
+            def acquire(self, key, ttl_seconds, wait_timeout=0.0):
+                seen.append(wait_timeout)
+                return None
+
+            def release(self, key, token):  # pragma: no cover - never held
+                pass
+
+        backend = RecordingLock()
+        assert asyncio.run(backend.acquire_async("k", ttl_seconds=5, wait_timeout=0.15)) is None
+        assert seen, "acquire was never attempted"
+        assert set(seen) == {0.0}, f"blocking waits leaked to the executor: {sorted(set(seen))}"
+
+
+class TestAsyncLockCancellation:
+    """A cancelled waiter must not strand the lock for a whole TTL.
+
+    ASGI hosts cancel the request task when a client disconnects. A thread
+    cannot be interrupted, so an acquisition attempt already in flight can
+    still win the lock after its waiter is gone — the token would be lost and
+    the upload locked until ``lock_ttl_seconds`` expires.
+    """
+
+    class SlowBackend(LockBackend):
+        """Stands in for a network-backed lock: non-blocking, but a slow hop."""
+
+        def __init__(self) -> None:
+            self.held: str | None = None
+            self.wins = 0
+
+        def acquire(self, key, ttl_seconds, wait_timeout=0.0):
+            time.sleep(0.15)
+            if self.held is None:
+                self.held = "tok"
+                self.wins += 1
+                return self.held
+            return None
+
+        def release(self, key, token):
+            if self.held == token:
+                self.held = None
+
+    def test_cancelled_waiter_releases_a_lock_it_won_anyway(self):
+        backend = self.SlowBackend()
+
+        async def scenario():
+            waiter = asyncio.create_task(backend.acquire_async("k", ttl_seconds=60, wait_timeout=5))
+            await asyncio.sleep(0.05)  # cancel while the attempt is in flight
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+            # The orphaned attempt finishes on its own schedule. Wait for it to
+            # win and then be released, rather than guessing how long a loaded
+            # runner needs — and keep the loop alive meanwhile, since the
+            # release runs as a done-callback on this loop.
+            deadline = time.monotonic() + 2.0
+            while not (backend.wins and backend.held is None) and time.monotonic() < deadline:
+                await asyncio.sleep(0.01)
+
+        asyncio.run(scenario())
+        assert backend.wins == 1, "the in-flight attempt never won; nothing was exercised"
+        assert backend.held is None, (
+            "a cancelled waiter stranded the lock; it stays held until the TTL expires"
+        )
+
+
+class TestAsyncServerPathNotStarvedByWaiters:
+    """The regression test for the site the bug lived in: ``_with_lock_async``.
+
+    Testing ``acquire_async`` alone is not enough — the defect was that
+    ``TusServerCore._with_lock_async`` handed the *blocking* ``acquire`` to
+    ``asyncio.to_thread``. The lock holder's storage ``*_async`` calls draw
+    from that same default executor, so waiters pinning workers starve the
+    holder that would release them.
+    """
+
+    def _server(self, tmp_path):
+        import os
+
+        from resumable_upload.server import TusServer
+        from resumable_upload.storage import SQLiteStorage
+
+        class SlowStorage(SQLiteStorage):
+            """Holds the lock long enough that the holder needs a worker thread."""
+
+            def write_chunk(self, upload_id, offset, data):
+                time.sleep(0.05)
+                super().write_chunk(upload_id, offset, data)
+
+        return TusServer(
+            storage=SlowStorage(
+                db_path=os.path.join(str(tmp_path), "u.db"),
+                upload_dir=os.path.join(str(tmp_path), "files"),
+            ),
+            base_path="/files",
+            lock_backend=PlainLockBackend(),
+            lock_wait_seconds=3.0,
+        )
+
+    def test_concurrent_async_patches_do_not_starve_the_holder(self, tmp_path):
+        server = self._server(tmp_path)
+        _, headers, _ = server.handle_request(
+            "POST", "/files", {"Tus-Resumable": "1.0.0", "Upload-Length": "2"}, b""
+        )
+        location = headers["Location"]
+
+        async def scenario():
+            # Fewer workers than waiters: a waiter that pins one blocks the
+            # holder's write_chunk_async from ever getting a thread.
+            asyncio.get_running_loop().set_default_executor(ThreadPoolExecutor(max_workers=2))
+            patch_headers = {
+                "Tus-Resumable": "1.0.0",
+                "Upload-Offset": "0",
+                "Content-Type": "application/offset+octet-stream",
+            }
+            t0 = time.monotonic()
+            results = await asyncio.gather(
+                *(
+                    server.handle_request_async("PATCH", location, dict(patch_headers), b"hi")
+                    for _ in range(5)
+                )
+            )
+            return [r[0] for r in results], time.monotonic() - t0
+
+        statuses, elapsed = asyncio.run(scenario())
+
+        assert statuses.count(204) == 1, f"expected exactly one winner, got {statuses}"
+        assert 423 not in statuses, (
+            f"a waiter hit the {server._lock_wait}s lock timeout: {statuses}; "
+            "the holder was starved of an executor thread"
+        )
+        assert elapsed < 2.0, (
+            f"5 concurrent PATCHes took {elapsed:.2f}s against a "
+            f"{server._lock_wait}s lock wait; waiters are pinning the executor"
+        )


### PR DESCRIPTION
## Purpose

`_with_lock_async` handed the blocking `acquire` to `asyncio.to_thread`, pinning an executor worker for the whole `lock_wait_seconds`. The holder's storage `*_async` calls draw from the same pool, so waiters starved the very holder that would release them on a 2-worker pool, 4 waiters delayed a storage call by 5.9s. Newly reachable since `TusServer` gained a default lock backend in the unreleased delta.

Add `acquire_async` / `release_async`: the base polls the non-blocking `acquire(wait_timeout=0)` and waits on the event loop, so a thread is held for one attempt only. Cancellation is shielded so a won-but-abandoned lock is released instead of stranded until the TTL.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
