### PR TITLE
feat(cli): expose cleanup interval and lock timeouts on serve

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -184,19 +184,21 @@ app.mount("/files", TusASGIApp(tus))
 
 어댑터는 `TusServer.handle_request_async`를 직접 await합니다. 기본 `*_async` 구현을 유지하는 스토리지 백엔드는 `asyncio.to_thread` 기반 래퍼를 그대로 사용하므로 별도 수정 없이 이벤트 루프가 블로킹되지 않습니다. `*_async`를 네이티브 비동기 I/O로 오버라이드한 백엔드는 논블로킹으로 end-to-end 실행됩니다.
 
-### 커맨드라인 서버
+### 커맨드라인 서버 & 클라이언트
 
-Python 코드를 작성하지 않고 쉘에서 바로 TUS 서버를 실행할 수 있습니다:
+Python 코드를 작성하지 않고 쉘에서 바로 TUS 서버를 실행하거나, 서버를 상대로 업로드·다운로드·조회를 할 수 있습니다:
 
 ```bash
-# 콘솔 스크립트 (pip/uv 설치 후)
+# 서버
 resumable-upload serve --host 0.0.0.0 --port 8080 --upload-dir ./uploads
 
-# 모듈 실행
-python -m resumable_upload serve --port 8080
+# 클라이언트: 업로드(재개 가능, 진행률 표시), 조회, 다운로드
+resumable-upload upload big.bin --url http://host/files --parallel 4
+resumable-upload info http://host/files/<id>
+resumable-upload download http://host/files/<id> -o out.bin
 ```
 
-플래그: `--host`, `--port`, `--base-path`, `--upload-dir`, `--db-path`, `--max-size`, `--max-chunk-size`, `--request-timeout`, `--upload-expiry`, `--cors-origin`, `--cors-credentials`, `--cors-max-age`, `--checksum-algorithms`, `--enable-downloads`, `--behind-proxy`, `--location-base-url`, `--disable-termination`, `--disable-concatenation`, `--metrics-path`, `--lock-backend`, `--redis-url`, `--log-level`. 자세한 내용은 `resumable-upload serve --help`로 확인하세요.
+서버 플래그: `--host`, `--port`, `--base-path`, `--upload-dir`, `--db-path`, `--max-size`, `--max-chunk-size`, `--request-timeout`, `--upload-expiry`, `--cleanup-interval`, `--cors-origin`, `--cors-credentials`, `--cors-max-age`, `--checksum-algorithms`, `--enable-downloads`, `--behind-proxy`, `--location-base-url`, `--disable-termination`, `--disable-concatenation`, `--metrics-path`, `--lock-backend`, `--redis-url`, `--lock-ttl`, `--lock-wait`, `--log-level`. 자세한 내용은 `resumable-upload serve --help`로 확인하세요.
 
 `serve`는 연결마다 스레드를 하나씩 사용하므로 동시 `PATCH`, `--parallel` 업로드, 락 경합이 실제 운영 환경과 동일하게 동작합니다. `SIGINT`/`SIGTERM`을 받으면 새 연결을 받지 않고 처리 중인 요청이 끝나기를 기다린 뒤 종료하며, 대기 시간은 `--request-timeout`(기본 30초)으로 제한됩니다 — 멈춘 클라이언트 때문에 종료가 `SIGKILL`까지 밀리지 않도록 오케스트레이터의 grace period보다 작게 두세요. 연결당 스레드 하나를 상한 없이 사용하므로, 번들 서버는 직접 노출하지 말고 리버스 프록시 뒤에 두는 것을 권장합니다.
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ resumable-upload info http://host/files/<id>
 resumable-upload download http://host/files/<id> -o out.bin
 ```
 
-Server flags: `--host`, `--port`, `--base-path`, `--upload-dir`, `--db-path`, `--max-size`, `--max-chunk-size`, `--request-timeout`, `--upload-expiry`, `--cors-origin`, `--cors-credentials`, `--cors-max-age`, `--checksum-algorithms`, `--enable-downloads`, `--behind-proxy`, `--location-base-url`, `--disable-termination`, `--disable-concatenation`, `--metrics-path`, `--lock-backend`, `--redis-url`, `--log-level`. Run `resumable-upload serve --help` for details.
+Server flags: `--host`, `--port`, `--base-path`, `--upload-dir`, `--db-path`, `--max-size`, `--max-chunk-size`, `--request-timeout`, `--upload-expiry`, `--cleanup-interval`, `--cors-origin`, `--cors-credentials`, `--cors-max-age`, `--checksum-algorithms`, `--enable-downloads`, `--behind-proxy`, `--location-base-url`, `--disable-termination`, `--disable-concatenation`, `--metrics-path`, `--lock-backend`, `--redis-url`, `--lock-ttl`, `--lock-wait`, `--log-level`. Run `resumable-upload serve --help` for details.
 
 `serve` handles each connection on its own thread, so concurrent `PATCH`es, `--parallel` uploads and lock contention behave the way they will in production. `SIGINT`/`SIGTERM` stop accepting new connections and wait for in-flight requests to finish, bounded by `--request-timeout` (30s default) — set it below your orchestrator's grace period so a stalled client can't push the drain into a `SIGKILL`. Threads are one-per-connection and uncapped, so put the bundled server behind a reverse proxy rather than exposing it directly.
 

--- a/docs/operations/cli.md
+++ b/docs/operations/cli.md
@@ -28,6 +28,7 @@ resumable-upload serve --host 0.0.0.0 --port 8080 --upload-dir ./uploads
 | `--max-chunk-size` | `0` | Max single PATCH size in bytes (0 = unlimited) |
 | `--request-timeout` | `30` | Socket read timeout in seconds; also caps how long a stalled connection delays a graceful shutdown |
 | `--upload-expiry` | unset | Upload expiry in seconds (unset = no expiry) |
+| `--cleanup-interval` | `60` | Minimum seconds between expired-upload cleanup runs |
 | `--cors-origin` | unset | `Access-Control-Allow-Origin` value (unset = no CORS) |
 | `--cors-credentials` | off | Send `Access-Control-Allow-Credentials`; a `*` origin is echoed per request |
 | `--cors-max-age` | unset | `Access-Control-Max-Age` (seconds) on preflight responses |
@@ -36,6 +37,8 @@ resumable-upload serve --host 0.0.0.0 --port 8080 --upload-dir ./uploads
 | `--metrics-path` | unset | Path to expose Prometheus-text metrics on (unset = disabled) |
 | `--lock-backend` | `memory` | One of `none`, `memory`, `redis` |
 | `--redis-url` | unset | Redis URL, e.g., `redis://localhost:6379/0` (required when `--lock-backend=redis`) |
+| `--lock-ttl` | `60` | Lock TTL in seconds. Also the bound on the guarantee: a chunk write that outruns it can be joined by a second writer — raise it above your slowest expected chunk write. Ignored with `--lock-backend=none` |
+| `--lock-wait` | `5` | How long to wait for a contended lock before returning `423 Locked`. Ignored with `--lock-backend=none` |
 
 ### Examples
 

--- a/resumable_upload/cli.py
+++ b/resumable_upload/cli.py
@@ -150,6 +150,26 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Redis URL (e.g., redis://localhost:6379/0), required when --lock-backend=redis",
     )
+    serve.add_argument(
+        "--lock-ttl",
+        type=float,
+        default=60.0,
+        help="Lock TTL in seconds; a holder that outruns it can be joined "
+        "by a second writer (default: 60). Ignored with --lock-backend=none.",
+    )
+    serve.add_argument(
+        "--lock-wait",
+        type=float,
+        default=5.0,
+        help="How long to wait for a contended lock before returning 423 "
+        "(default: 5). Ignored with --lock-backend=none.",
+    )
+    serve.add_argument(
+        "--cleanup-interval",
+        type=int,
+        default=60,
+        help="Minimum seconds between expired-upload cleanup runs (default: 60)",
+    )
 
     # -- client subcommands ------------------------------------------------
     upload = sub.add_parser("upload", help="Upload a file to a TUS server.")
@@ -221,6 +241,7 @@ def _serve(args: argparse.Namespace) -> int:
         max_size=args.max_size,
         max_chunk_size=args.max_chunk_size,
         upload_expiry=args.upload_expiry,
+        cleanup_interval=args.cleanup_interval,
         request_timeout=args.request_timeout,
         cors_allow_origins=args.cors_origin,
         cors_allow_credentials=args.cors_credentials,
@@ -231,6 +252,8 @@ def _serve(args: argparse.Namespace) -> int:
         metrics_registry=metrics,
         metrics_path=args.metrics_path or "/metrics",
         lock_backend=lock_backend,
+        lock_ttl_seconds=args.lock_ttl,
+        lock_wait_seconds=args.lock_wait,
         # The bundled stdlib transport parses chunked bodies + trailers.
         supports_checksum_trailer=True,
         enable_downloads=args.enable_downloads,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -441,3 +441,67 @@ class TestCLIServeConcurrency:
             release.set()
             caller.join(5)
         assert result == [b"drained"]
+
+
+class TestServeTuningFlags:
+    """Deployer knobs on TusServerCore must be reachable from `serve`.
+
+    CLAUDE.md calls out this gap class: an option lands on the server and the
+    CLI never grows a flag for it.
+    """
+
+    def _capture_server_kwargs(self, monkeypatch, tmp_path, *flags: str) -> dict:
+        from resumable_upload import cli
+
+        captured: dict = {}
+
+        class FakeServer:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        class FakeHTTPD:
+            def __init__(self, addr, handler):
+                pass
+
+            def serve_forever(self):
+                pass
+
+            def server_close(self):
+                pass
+
+        monkeypatch.setattr(cli, "TusServer", FakeServer)
+        monkeypatch.setattr(cli, "_ThreadingHTTPServer", FakeHTTPD)
+        # _serve installs SIGINT/SIGTERM handlers bound to the httpd it built.
+        # Left in place they outlive the test and replace pytest's own Ctrl+C.
+        monkeypatch.setattr(cli.signal, "signal", lambda *_: None)
+        argv = [
+            "serve",
+            "--db-path",
+            str(tmp_path / "u.db"),
+            "--upload-dir",
+            str(tmp_path / "uploads"),  # the default would land in the CWD
+            *flags,
+        ]
+        cli._serve(cli._build_parser().parse_args(argv))
+        return captured
+
+    def test_defaults_match_the_server_defaults(self, monkeypatch, tmp_path):
+        kwargs = self._capture_server_kwargs(monkeypatch, tmp_path)
+        assert kwargs["cleanup_interval"] == 60
+        assert kwargs["lock_ttl_seconds"] == 60.0
+        assert kwargs["lock_wait_seconds"] == 5.0
+
+    def test_flags_reach_the_server(self, monkeypatch, tmp_path):
+        kwargs = self._capture_server_kwargs(
+            monkeypatch,
+            tmp_path,
+            "--cleanup-interval",
+            "5",
+            "--lock-ttl",
+            "12.5",
+            "--lock-wait",
+            "0.25",
+        )
+        assert kwargs["cleanup_interval"] == 5
+        assert kwargs["lock_ttl_seconds"] == 12.5
+        assert kwargs["lock_wait_seconds"] == 0.25


### PR DESCRIPTION
## Purpose

`TusServerCore` takes `cleanup_interval`, `lock_ttl_seconds` and `lock_wait_seconds`; `serve` exposed none of them — a deployer could pick a lock backend but not its 423 threshold, set `--upload-expiry` but not the sweep cadence. Defaults mirror the server's, so nothing changes until a flag is passed.

Also fills in the Korean README's CLI section, which never mentioned `upload` / `download` / `info`.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
