### PR TITLE
docs: correct API defaults and unbacked compliance claims

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -19,7 +19,7 @@
 - 📊 **진행률 추적**: `UploadStats` 콜백으로 상세한 업로드 진행률 제공
 - 🌐 **웹 프레임워크 지원**: Flask, FastAPI, Django 통합
 - 🐍 **Python 3.9+**: Python 3.9부터 3.14까지 지원
-- 🏪 **스토리지 백엔드**: SQLite 기반 스토리지 (커스텀 백엔드로 확장 가능)
+- 🏪 **스토리지 백엔드**: 기본 SQLite, 선택 extras로 S3 · Google Cloud Storage · Azure Blob Storage (커스텀 백엔드로 확장 가능)
 - 🔐 **TLS 지원**: 인증서 검증 제어 및 mTLS 인증
 - 📝 **URL 스토리지**: 세션 간 업로드 URL 유지
 - ⬇️ **다운로드 엔드포인트**: 완료된 업로드를 GET으로 서빙 (tusd 스타일, opt-in, 안전한 헤더 기본값)
@@ -288,6 +288,8 @@ final_url = client.create_final_upload(
 | 기능 | 상태 |
 |------|------|
 | `X-HTTP-Method-Override` | ✅ 구현됨 — PATCH/DELETE를 차단하는 환경을 위해 POST를 PATCH/DELETE/HEAD로 재작성 |
+| `423 Locked` | ✅ 구현됨 — `LockBackend` 보유자가 업로드를 점유한 채 `lock_wait_seconds`가 지나면 반환 |
+| GET 다운로드 엔드포인트 | ✅ 구현됨 — `enable_downloads`로 옵트인, 완료된 업로드를 tusd 방식으로 서빙 |
 
 ## 🧪 테스트
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Python implementation of the [TUS resumable upload protocol](https://tus.io/) 
 - 📊 **Progress Tracking**: Detailed upload progress callbacks with stats
 - 🌐 **Web Framework Support**: Integration examples for Flask, FastAPI, and Django
 - 🐍 **Python 3.9+**: Supports Python 3.9 through 3.14
-- 🏪 **Storage Backend**: SQLite-based storage (extensible to other backends)
+- 🏪 **Storage Backends**: SQLite by default; S3, Google Cloud Storage and Azure Blob Storage via optional extras (and extensible to your own)
 - 🔐 **TLS Support**: Certificate verification control and mTLS authentication
 - 📝 **URL Storage**: Persist upload URLs across sessions
 - ⬇️ **Download Endpoint**: Opt-in tusd-style GET serving of completed uploads with safe headers
@@ -305,6 +305,8 @@ This library implements [TUS protocol v1.0.0](https://tus.io/protocols/resumable
 | Feature | Status |
 |---------|--------|
 | `X-HTTP-Method-Override` | ✅ Implemented — POST rewrites to PATCH/DELETE/HEAD for environments that block those methods |
+| `423 Locked` | ✅ Implemented — returned when a `LockBackend` holder still owns the upload and `lock_wait_seconds` elapses |
+| GET download endpoint | ✅ Implemented — opt-in via `enable_downloads`; tusd-style serving of completed uploads |
 
 ## 🧪 Testing
 

--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -49,6 +49,7 @@ client.upload_file(
     progress_callback=None,
     stop_at=None,
     parallel_uploads=1,
+    metadata_for_partial_uploads=None,
 ) -> str
 ```
 
@@ -56,6 +57,7 @@ Upload a file. Returns the upload URL.
 
 - `stop_at` (int): Stop upload at this byte offset (for partial uploads). Clamped to file size automatically.
 - `parallel_uploads` (int): When `> 1`, splits the file into N byte ranges, uploads each as a TUS partial upload concurrently, and merges them server-side via the `concatenation` extension. Requires `file_path` (streams cannot be split) and is incompatible with `stop_at`. The server must support `concatenation`.
+- `metadata_for_partial_uploads` (dict): Metadata attached to each partial upload instead of `metadata`, which stays on the final. Mirrors `tus-js-client`'s `metadataForPartialUploads`; only meaningful with `parallel_uploads > 1`.
 
 #### `resume_upload`
 
@@ -129,6 +131,36 @@ client.create_uploader(
 
 Create an `Uploader` instance for fine-grained chunk-level control.
 
+#### `get_metadata` / `encode_metadata`
+
+```python
+client.get_metadata(upload_url) -> dict[str, str]   # decode the server's Upload-Metadata
+client.encode_metadata({"filename": "a.bin"}) -> list[str]  # the wire form this client sends
+```
+
+`get_metadata` issues a HEAD and decodes the base64 pairs; `encode_metadata` is the pure
+encoder, useful when building requests by hand or asserting on the wire format in tests.
+
+#### `update_headers` / `get_headers`
+
+```python
+client.update_headers({"Authorization": "Bearer …"})  # merge into every subsequent request
+client.get_headers() -> dict[str, str]                # a copy of the current headers
+```
+
+Use `update_headers` to rotate a token mid-session without rebuilding the client.
+
+#### `get_file_size` / `get_file_stream`
+
+```python
+client.get_file_size(file_source) -> int   # file_source: a path or a file-like object
+client.get_file_stream(file_source) -> IO
+```
+
+The same resolution the upload methods use internally — size via `os.stat` or by seeking
+the stream, and a readable stream from either input. Handy when you need the byte count
+before deciding on `parallel_uploads` or `chunk_size`.
+
 ### Observability hooks
 
 ```python
@@ -181,6 +213,11 @@ Typically obtained via `TusClient.create_uploader()`.
 | `timeout` | float | `30.0` | Per-request timeout in seconds |
 | `stop_event` | threading.Event | `None` | When set, interrupts retry wait and raises `TusUploadFailed`. Useful for cancellation in threaded applications. |
 | `before_request` / `after_response` / `on_should_retry` | Callable | `None` | Same hooks as `TusClient`; forwarded automatically when the uploader is created via `TusClient.create_uploader()`. |
+| `metadata_encoding` | str | `"utf-8"` | Encoding used before base64 for `Upload-Metadata` values |
+| `headers` | dict | `None` | Extra headers sent on every request |
+| `ssl_context` | ssl.SSLContext | `None` | TLS context — certificate verification control and mTLS client certificates |
+| `override_patch_method` | bool | `False` | Tunnel PATCH as POST with `X-HTTP-Method-Override` |
+| `add_request_id` | bool | `False` | Attach a per-request UUID `X-Request-ID` (a user-supplied header wins) |
 
 ### 409 Handling
 

--- a/docs/api-reference/exceptions.md
+++ b/docs/api-reference/exceptions.md
@@ -30,11 +30,11 @@ Both exceptions expose:
 ```python
 from resumable_upload.exceptions import TusHookError
 
-raise TusHookError("Forbidden", status_code=403)  # status_code defaults to 400
+raise TusHookError("Upload not allowed", status_code=400)  # status_code defaults to 403
 ```
 
-- `status_code` (int): HTTP status code to return to the client (default: 400)
-- `body` (str): Response body to return to the client
+- `status_code` (int): HTTP status code to return to the client (default: 403)
+- `body` (str): Response body to return to the client (default: `"Forbidden"`)
 
 ---
 

--- a/docs/api-reference/server.md
+++ b/docs/api-reference/server.md
@@ -2,11 +2,26 @@
 
 ## TusServer
 
-TUS 1.0.0 protocol server implementation.
+TUS 1.0.0 protocol server implementation. This is the class to instantiate.
 
 ```python
 from resumable_upload import TusServer
 ```
+
+!!! note "`TusServer` vs `TusServerCore`"
+
+    `TusServerCore` holds the whole protocol implementation; `TusServer` subclasses it and
+    differs in exactly one way — it defaults `lock_backend` to an `InMemoryLockBackend`, so
+    concurrent `PATCH` / `DELETE` on the same upload are serialized out of the box.
+
+    ```python
+    from resumable_upload import TusServerCore
+    ```
+
+    Reach for `TusServerCore` when you want the minimal, lock-free surface — you are
+    supplying your own serialization, or embedding the server somewhere a process-local
+    lock would be misleading. Everything below applies to both; only the `lock_backend`
+    default differs. See [Locks](../operations/locks.md).
 
 ### Parameters
 
@@ -30,8 +45,8 @@ from resumable_upload import TusServer
 | `on_before_terminate` | Callable | `None` | Blocking hook before a client DELETE (tusd's pre-terminate). Raise `TusHookError` to veto. |
 | `metrics_registry` | MetricsRegistry | `None` | Enable Prometheus-text metrics (`/metrics` by default). See [Metrics](../operations/metrics.md). |
 | `metrics_path` | str | `"/metrics"` | Path to expose metrics on |
-| `lock_backend` | LockBackend | `None` | Distributed lock for PATCH / DELETE write paths. See [Locks](../operations/locks.md). |
-| `lock_ttl_seconds` | float | `60.0` | TTL applied when acquiring a lock (released sooner if the request finishes; expired automatically if the holder crashes) |
+| `lock_backend` | LockBackend | `InMemoryLockBackend()` on `TusServer`, `None` on `TusServerCore` | Lock guarding PATCH / DELETE write paths. Pass `None` to opt out, or a `RedisLockBackend` for multi-process / multi-node. See [Locks](../operations/locks.md). |
+| `lock_ttl_seconds` | float | `60.0` | TTL applied when acquiring a lock (released sooner if the request finishes; expired automatically if the holder crashes). Also the bound on the guarantee: a chunk write that outruns the TTL can be joined by a second writer. |
 | `lock_wait_seconds` | float | `5.0` | How long to wait for a contended lock before returning `423 Locked` |
 | `checksum_algorithms` | tuple[str, …] | `("sha1",)` | Algorithms to advertise via `Tus-Checksum-Algorithm` and accept on `Upload-Checksum`. Allowed: `sha1`, `sha256`, `sha512`, `md5`. |
 | `supports_checksum_trailer` | bool | `False` | Advertise `checksum-trailer`. Set only when the transport parses chunked bodies + trailers and merges a trailing `Upload-Checksum` into the headers — the bundled `TusHTTPRequestHandler` / `serve` CLI does. |

--- a/docs/compliance.md
+++ b/docs/compliance.md
@@ -144,7 +144,7 @@ Summary: ahead of tusd on **protocol surface** (checksum, expiration, unfinished
 | **Resume across sessions** | ✅ fingerprint → urlStorage (localStorage, default **on**) · ✅ `findPreviousUploads()` / `resumeFromPreviousUpload()` | ✅ fingerprint → URL storage (File/SQLite/Memory backends, default **off** via `store_url`) · ✅ `find_previous_uploads()` / `resume_upload()` |
 | **Fingerprint strength** | ✅ pluggable · ❌ weak default (name/size-based) | ✅ full-file SHA-256 default (collision-proof, costlier) · ✅ partial-MD5 and callable alternatives |
 | **Parallel upload (concatenation)** | ✅ `parallelUploads=N` · ✅ custom `parallelUploadBoundaries` · ✅ `metadataForPartialUploads` | ✅ `parallel_uploads=N` · ✅ `metadata_for_partial_uploads` · ❌ custom boundaries (even split only, deliberately skipped) |
-| **creation-with-upload** | ✅ `uploadDataDuringCreation` | ✅ `initial_data` on create |
+| **creation-with-upload** | ✅ `uploadDataDuringCreation` | ❌ no public option (the *server* implements the extension; the client always sends an empty creation POST) |
 | **defer-length** | ✅ `uploadLengthDeferred` | ✅ `create_deferred_upload()` |
 | **Termination** | ✅ `abort(true)` / static `terminate()` | ✅ `delete_upload()` |
 | **Pause / partial stop** | ✅ `abort()` (resume later) · ❌ stop-at-byte | ✅ `stop_event` (interrupt-safe) · ✅ `stop_at` byte offset |
@@ -156,15 +156,16 @@ Summary: ahead of tusd on **protocol surface** (checksum, expiration, unfinished
 | **Async** | ✅ Promise-based | ✅ separate `AsyncTusClient` (httpx, `[async]` extra) |
 | **tus2 / IETF RUFH** | ✅ experimental `protocol: 'ietf-draft-03'/'ietf-draft-05'` | ❌ (tracked) |
 
-Summary: ahead on **integrity** (checksum), **fingerprint strength**, TLS/mTLS, and stats-rich progress; behind only on **RUFH experimentation** and custom parallel boundaries.
+Summary: ahead on **integrity** (checksum), **fingerprint strength**, TLS/mTLS, and stats-rich progress; behind on **RUFH experimentation**, custom parallel boundaries, and **client-side creation-with-upload** (the server supports it; the client cannot yet send data with the creation POST).
 
 ## Error Response Reference
 
 | Status | Meaning | Trigger |
 |--------|---------|---------|
 | `400` | Bad Request | Missing/invalid header, negative offset, chunk overflow, oversized metadata, unsupported checksum algorithm, malformed `Upload-Concat`, partial referenced by a final that isn't complete |
-| `403` | Forbidden | PATCH on already completed upload |
+| `403` | Forbidden | PATCH on an already completed upload, or on a final upload still waiting on its partials. Also the default status of `TusHookError`. |
 | `404` | Not Found | Unknown upload ID |
+| `405` | Method Not Allowed | Client `DELETE` while `disable_termination=True` |
 | `409` | Conflict | `Upload-Offset` mismatch or concurrent write conflict |
 | `410` | Gone | Upload has expired |
 | `412` | Precondition Failed | Unsupported TUS version |
@@ -172,6 +173,8 @@ Summary: ahead on **integrity** (checksum), **fingerprint strength**, TLS/mTLS, 
 | `415` | Unsupported Media Type | Wrong `Content-Type` in PATCH |
 | `423` | Locked | `LockBackend` contention; another holder still owns the upload |
 | `460` | Checksum Mismatch | Configured-algorithm digest verification failed |
+| `500` | Internal Server Error | A pre-hook raised something other than `TusHookError` |
+| `501` | Not Implemented | A custom `Storage` backend raised `NotImplementedError` from `concatenate_uploads` |
 
 ## References
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,9 @@ A Python implementation of the [TUS resumable upload protocol](https://tus.io/) 
 - **Progress Tracking** — detailed `UploadStats` callback
 - **Async** — awaitable `AsyncTusClient` (`[async]` extra, httpx) and an ASGI server adapter (`TusASGIApp`) that awaits `handle_request_async`
 - **Web Framework Support** — Flask, FastAPI, Django, plus a generic ASGI adapter (`TusASGIApp`)
-- **Command-line Server** — `resumable-upload serve` console script for running a TUS server with no Python boilerplate
-- **Concatenation Extension** — server-side merge of partial uploads (SQLite, S3, GCS, Azure); `parallel_uploads=N` on the client
+- **Command-line Server & Client** — `resumable-upload serve` runs a TUS server; `upload` / `download` / `info` drive one from the shell, with no Python boilerplate
+- **Concatenation Extension** — server-side merge of partial uploads (SQLite, S3, GCS, Azure), including `concatenation-unfinished` when the backend supports it; `parallel_uploads=N` on the client
+- **Download Endpoint** — opt-in `enable_downloads` serves completed uploads over GET, tusd-style, with safe headers
 - **Deferred Length** — `Upload-Defer-Length` extension for streams whose total size is unknown at creation
 - **Operability** — pluggable Prometheus-text metrics registry and pluggable distributed `LockBackend` (in-memory + Redis)
 - **Cloud Storage** — S3, Google Cloud Storage, Azure Blob Storage backends (optional dependencies)

--- a/resumable_upload/storage/sqlite_storage.py
+++ b/resumable_upload/storage/sqlite_storage.py
@@ -258,6 +258,14 @@ class SQLiteStorage(Storage):
         thread without the server's own lock, so without this it can remove a
         file another thread is mid-``write_chunk`` on. On POSIX the unlink
         succeeds and the writer's bytes go to an orphaned inode.
+
+        The lock does not close the row-then-file ordering below. A PATCH that
+        read its upload before the row was deleted still calls ``write_chunk``,
+        which recreates the file (``update_offset_atomic`` then fails it with a
+        409, correctly). The upload is gone from the DB, so the file is left in
+        ``upload_dir`` with nothing referencing it and DB-driven expiry cleanup
+        never reclaims it. Sweep ``upload_dir`` for files with no row if that
+        matters to you.
         """
         conn = sqlite3.connect(self.db_path, timeout=self.timeout)
         try:


### PR DESCRIPTION
## Purpose

Three docs claims contradicted the code: `TusHookError.status_code` defaults to 403 (not 400), `TusServer.lock_backend` defaults to `InMemoryLockBackend` (not `None`), and the compliance table advertised client-side creation-with-upload that has no public parameter.

Fills the gaps found alongside — undocumented 405/500/501 responses, the 423 and download rows missing from both READMEs, and public API with no reference entry. Also drops the SQLite `delete_upload` docstring's claim that the per-upload lock closes the create/delete race; it doesn't close the row-then-file ordering.

## Test Plan

<!-- How you verified the change. Commands, scenarios, fixtures. -->

## Test Result

<!-- Output / evidence. pytest excerpt, ruff/ty status, before-after if relevant. -->

---

<details>
<summary>Checklist</summary>

- [ ] PR title follows Conventional Commits (`type(scope): ...`)
- [ ] `pytest -v` passes locally
- [ ] `ruff check` / `ruff format --check` / `ty check resumable_upload` clean
- [ ] Tests added for new behavior or regression
- [ ] No new core runtime dependencies (cloud SDKs go in optional extras)
- [ ] If wire/header/status-code behavior changed, `TUS_COMPLIANCE.md` updated
- [ ] Docs / examples updated if user-facing behavior changed

</details>
